### PR TITLE
Make sure dashboard id is null

### DIFF
--- a/contrib/kube-prometheus/hack/scripts/wrap-dashboard.sh
+++ b/contrib/kube-prometheus/hack/scripts/wrap-dashboard.sh
@@ -46,5 +46,4 @@ cat >> $temp <<EOF
 }
 EOF
 
-mv $temp $json
-
+jq '.dashboard | if .id != null then .id = null else . end' $temp > $json


### PR DESCRIPTION
This `null`ize the dashboard `id` to make sure it'll be picked up by `grafana-watcher`.