### PR TITLE
Adjust Prometheus for production

### DIFF
--- a/contrib/kube-prometheus/assets/grafana/kubernetes-cluster-dashboard.json
+++ b/contrib/kube-prometheus/assets/grafana/kubernetes-cluster-dashboard.json
@@ -9,7 +9,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "hideControls": false,
-  "id": 1,
+  "id": null,
   "links": [
     {
       "asDropdown": true,

--- a/contrib/kube-prometheus/assets/grafana/kubernetes-pod-dashboard.json
+++ b/contrib/kube-prometheus/assets/grafana/kubernetes-pod-dashboard.json
@@ -1,672 +1,763 @@
 {
-  "dashboard":
-{
-  "annotations": {
-    "list": []
-  },
-  "description": "Summary metrics about Pods running on Kubernetes nodes.",
-  "editable": true,
-  "gnetId": 482,
-  "graphTooltip": 1,
-  "hideControls": false,
-  "id": null,
-  "links": [
-    {
-      "asDropdown": true,
-      "icon": "external link",
-      "includeVars": true,
-      "tags": [
-        "kubernetes-app"
-      ],
-      "title": "Dashboards",
-      "type": "dashboards"
-    }
-  ],
-  "refresh": "10s",
-  "rows": [
-    {
-      "collapse": false,
-      "height": 355,
-      "panels": [
-        {
-          "alerting": {},
-          "aliasColors": {},
-          "bars": false,
-          "datasource": "$datasource",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "grid": {},
-          "id": 6,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": true,
-            "hideZero": false,
-            "max": true,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 2,
-          "links": [],
-          "minSpan": 6,
-          "nullPointMode": "connected",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "span": 6,
-          "stack": true,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum by (container_name)(rate(cluster_namespace_controller_pod_container:cpu_usage:rate{container_name!=\"POD\",pod_name=~\"$pod\"}[$interval] ) )",
-              "intervalFactor": 2,
-              "legendFormat": "{{ container_name }}",
-              "refId": "A",
-              "step": 4,
-              "target": "groupByNode(exclude(perSecond(snap.$cluster.$node.intel.docker.$namespace.$pod.$container.stats.cgroups.cpu_stats.cpu_usage.total_usage), 'POD'), 7, 'sum')",
-              "textEditor": false
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "CPU Usage (per container)",
-          "tooltip": {
-            "msResolution": false,
-            "shared": false,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "transparent": false,
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ]
-        },
-        {
-          "alerting": {},
-          "aliasColors": {},
-          "bars": false,
-          "datasource": "$datasource",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "grid": {},
-          "id": 1,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": false,
-            "max": true,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 2,
-          "links": [],
-          "minSpan": 6,
-          "nullPointMode": "connected",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "span": 6,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum by(container_name) (cluster_namespace_controller_pod_container:memory_usage:bytes{container_name!=\"POD\",pod_name=~\"$pod\"})",
-              "hide": false,
-              "intervalFactor": 1,
-              "legendFormat": " {{ container_name }}",
-              "refId": "A",
-              "step": 2,
-              "target": "groupByNode(exclude(averageAbove(snap.$cluster.$node.intel.docker.$namespace.$pod.$container.stats.cgroups.memory_stats.usage.usage, 0), 'POD'), 7, 'sum')",
-              "textEditor": false
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Total Memory Usage (per container)",
-          "tooltip": {
-            "msResolution": false,
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "decbytes",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ]
-        },
-        {
-          "alerting": {},
-          "aliasColors": {},
-          "bars": false,
-          "datasource": "$datasource",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "grid": {},
-          "id": 2,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 2,
-          "links": [],
-          "minSpan": 6,
-          "nullPointMode": "null as zero",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "span": 12,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum by(pod_name) (rate(container_network_receive_bytes_total{pod_name=~\"$pod.*\"}[$interval]))",
-              "intervalFactor": 2,
-              "legendFormat": "{{ pod_name }} Received",
-              "refId": "A",
-              "step": 2,
-              "target": "groupByNode(exclude(perSecond(snap.$cluster.$node.intel.docker.$namespace.$pod.$container.stats.network.*.rx_bytes), 'POD'), 7, 'sum')",
-              "textEditor": false
-            },
-            {
-              "expr": "-sum by(pod_name)  (rate(container_network_transmit_bytes_total{pod_name=~\"$pod.*\"}[$interval]))",
-              "intervalFactor": 2,
-              "legendFormat": "{{ pod_name }} Sent",
-              "refId": "B",
-              "step": 2
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Network Traffic (per pod)",
-          "tooltip": {
-            "msResolution": false,
-            "shared": false,
-            "sort": 0,
-            "value_type": "cumulative"
-          },
-          "transparent": false,
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "decbytes",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ]
-        }
-      ],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": true,
-      "title": "General",
-      "titleSize": "h6"
-    },
-    {
-      "collapse": false,
-      "height": 439,
-      "panels": [
-        {
-          "columns": [
-            {
-              "text": "Current",
-              "value": "current"
-            }
-          ],
-          "datasource": "prometheus",
-          "fontSize": "100%",
-          "id": 7,
-          "links": [],
-          "minSpan": 4,
-          "pageSize": null,
-          "scroll": true,
-          "showHeader": true,
-          "sort": {
-            "col": 0,
-            "desc": true
-          },
-          "span": 4,
-          "styles": [
-            {
-              "colorMode": null,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "decimals": 2,
-              "pattern": "/.*/",
-              "thresholds": [
-                "10000000",
-                " 25000000"
-              ],
-              "type": "number",
-              "unit": "decbytes"
-            }
-          ],
-          "targets": [
-            {
-              "expr": "cluster_namespace_controller_pod_container:memory_usage:bytes{container_name!=\"POD\",pod_name=~\"$pod\"}",
-              "intervalFactor": 2,
-              "legendFormat": "{{ container_name }}",
-              "refId": "A",
-              "step": 4
-            }
-          ],
-          "title": "Memory Usage",
-          "transform": "timeseries_aggregations",
-          "type": "table"
-        },
-        {
-          "columns": [
-            {
-              "text": "Current",
-              "value": "current"
-            }
-          ],
-          "datasource": "$datasource",
-          "fontSize": "100%",
-          "id": 8,
-          "links": [],
-          "minSpan": 4,
-          "pageSize": null,
-          "scroll": true,
-          "showHeader": true,
-          "sort": {
-            "col": 1,
-            "desc": true
-          },
-          "span": 4,
-          "styles": [
-            {
-              "colorMode": "cell",
-              "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(245, 54, 54, 0.9)"
-              ],
-              "decimals": 2,
-              "pattern": "/.*/",
-              "thresholds": [
-                "80",
-                "90"
-              ],
-              "type": "number",
-              "unit": "percent"
-            }
-          ],
-          "targets": [
-            {
-              "expr": "sum(100 - ((cluster_namespace_controller_pod_container:spec_memory_limit_bytes{container_name!=\"POD\",pod_name=~\"$pod\"} - cluster_namespace_controller_pod_container:memory_usage:bytes{container_name!=\"POD\",pod_name=~\"$pod\"})  * 100 / cluster_namespace_controller_pod_container:spec_memory_limit_bytes{container_name!=\"POD\",pod_name=~\"$pod\"}) ) by (pod_name) ",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "{{pod_name}}",
-              "refId": "A",
-              "step": 4
-            }
-          ],
-          "title": "Memory usage (in percent of limit)",
-          "transform": "timeseries_aggregations",
-          "type": "table"
-        },
-        {
-          "columns": [
-            {
-              "text": "Current",
-              "value": "current"
-            }
-          ],
-          "datasource": "$datasource",
-          "fontSize": "100%",
-          "id": 9,
-          "links": [],
-          "minSpan": 4,
-          "pageSize": null,
-          "scroll": true,
-          "showHeader": true,
-          "sort": {
-            "col": 0,
-            "desc": true
-          },
-          "span": 4,
-          "styles": [
-            {
-              "colorMode": "cell",
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "decimals": 2,
-              "pattern": "/.*/",
-              "thresholds": [
-                "0",
-                "0",
-                "1"
-              ],
-              "type": "number",
-              "unit": "short"
-            }
-          ],
-          "targets": [
-            {
-              "expr": "cluster_namespace_controller_pod_container:memory_oom:rate{container_name!=\"POD\", pod_name=~\"$pod\"}",
-              "intervalFactor": 2,
-              "legendFormat": "{{ container_name  }}",
-              "refId": "A",
-              "step": 4
-            }
-          ],
-          "title": "Out-of-memory",
-          "transform": "timeseries_aggregations",
-          "type": "table"
-        }
-      ],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": true,
-      "title": "Memory",
-      "titleSize": "h6"
-    }
-  ],
-  "schemaVersion": 14,
-  "style": "dark",
-  "tags": [
-    "kubernetes"
-  ],
-  "templating": {
-    "list": [
+  "dashboard": {
+    "__inputs": [
       {
-        "current": {
-          "text": "prometheus",
-          "value": "prometheus"
-        },
-        "hide": 2,
-        "label": "",
-        "name": "datasource",
-        "options": [],
-        "query": "prometheus",
-        "refresh": 1,
-        "regex": "",
+        "description": "",
+        "label": "prometheus",
+        "name": "DS_PROMETHEUS",
+        "pluginId": "prometheus",
+        "pluginName": "Prometheus",
         "type": "datasource"
+      }
+    ],
+    "__requires": [
+      {
+        "id": "graph",
+        "name": "Graph",
+        "type": "panel",
+        "version": ""
       },
       {
-        "auto": true,
-        "auto_count": 30,
-        "auto_min": "30s",
-        "current": {
-          "text": "3m",
-          "value": "3m"
+        "id": "grafana",
+        "name": "Grafana",
+        "type": "grafana",
+        "version": "3.1.1"
+      },
+      {
+        "id": "prometheus",
+        "name": "Prometheus",
+        "type": "datasource",
+        "version": "1.0.0"
+      }
+    ],
+    "annotations": {
+      "list": []
+    },
+    "description": "Summary metrics about Pods running on Kubernetes nodes.",
+    "editable": true,
+    "gnetId": 482,
+    "graphTooltip": 1,
+    "hideControls": false,
+    "id": null,
+    "links": [
+      {
+        "asDropdown": true,
+        "icon": "external link",
+        "includeVars": true,
+        "tags": [
+          "kubernetes-app"
+        ],
+        "title": "Dashboards",
+        "type": "dashboards"
+      }
+    ],
+    "refresh": "10s",
+    "rows": [
+      {
+        "collapse": false,
+        "height": 355,
+        "panels": [
+          {
+            "alerting": {},
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "$datasource",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 6,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": true,
+              "hideZero": false,
+              "max": true,
+              "min": false,
+              "rightSide": true,
+              "show": true,
+              "sideWidth": null,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "minSpan": 6,
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 6,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum (cluster_namespace_controller_pod_container:cpu_usage:rate{container_name!=\"POD\",pod_name=~\"$pod\"}) by (container_name)",
+                "intervalFactor": 2,
+                "legendFormat": "{{ container_name }}",
+                "refId": "A",
+                "step": 4,
+                "target": "groupByNode(exclude(perSecond(snap.$cluster.$node.intel.docker.$namespace.$pod.$container.stats.cgroups.cpu_stats.cpu_usage.total_usage), 'POD'), 7, 'sum')",
+                "textEditor": false
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU Usage (per container)",
+            "tooltip": {
+              "msResolution": false,
+              "shared": false,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": "of CPU cores",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "alerting": {},
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "$datasource",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 1,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "max": true,
+              "min": false,
+              "rightSide": true,
+              "show": true,
+              "sideWidth": null,
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "minSpan": 6,
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum by(container_name) (cluster_namespace_controller_pod_container:memory_usage:bytes{container_name!=\"POD\",pod_name=~\"$pod\"})",
+                "hide": false,
+                "intervalFactor": 1,
+                "legendFormat": " {{ container_name }}",
+                "refId": "A",
+                "step": 2,
+                "target": "groupByNode(exclude(averageAbove(snap.$cluster.$node.intel.docker.$namespace.$pod.$container.stats.cgroups.memory_stats.usage.usage, 0), 'POD'), 7, 'sum')",
+                "textEditor": false
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Total Memory Usage (per container)",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "decbytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "alerting": {},
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "$datasource",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 2,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": true,
+              "max": false,
+              "min": false,
+              "rightSide": true,
+              "show": true,
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "minSpan": 6,
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum by(pod_name) (rate(container_network_receive_bytes_total{pod_name=~\"$pod.*\"}[$interval]))",
+                "intervalFactor": 2,
+                "legendFormat": "{{ pod_name }} Received",
+                "refId": "A",
+                "step": 2,
+                "target": "groupByNode(exclude(perSecond(snap.$cluster.$node.intel.docker.$namespace.$pod.$container.stats.network.*.rx_bytes), 'POD'), 7, 'sum')",
+                "textEditor": false
+              },
+              {
+                "expr": "-sum by(pod_name)  (rate(container_network_transmit_bytes_total{pod_name=~\"$pod.*\"}[$interval]))",
+                "intervalFactor": 2,
+                "legendFormat": "{{ pod_name }} Sent",
+                "refId": "B",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Network Traffic (per pod)",
+            "tooltip": {
+              "msResolution": false,
+              "shared": false,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "decbytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "General",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 439,
+        "panels": [
+          {
+            "columns": [
+              {
+                "text": "Current",
+                "value": "current"
+              }
+            ],
+            "datasource": "prometheus",
+            "fontSize": "100%",
+            "id": 7,
+            "links": [],
+            "minSpan": 4,
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+              "col": 0,
+              "desc": true
+            },
+            "span": 4,
+            "styles": [
+              {
+                "colorMode": null,
+                "colors": [
+                  "rgba(245, 54, 54, 0.9)",
+                  "rgba(237, 129, 40, 0.89)",
+                  "rgba(50, 172, 45, 0.97)"
+                ],
+                "decimals": 2,
+                "pattern": "/.*/",
+                "thresholds": [
+                  "10000000",
+                  " 25000000"
+                ],
+                "type": "number",
+                "unit": "decbytes"
+              }
+            ],
+            "targets": [
+              {
+                "expr": "cluster_namespace_controller_pod_container:memory_usage:bytes{container_name!=\"POD\",pod_name=~\"$pod\"}",
+                "intervalFactor": 2,
+                "legendFormat": "{{ container_name }}",
+                "refId": "A",
+                "step": 4
+              }
+            ],
+            "title": "Memory Usage",
+            "transform": "timeseries_aggregations",
+            "type": "table"
+          },
+          {
+            "columns": [
+              {
+                "text": "Current",
+                "value": "current"
+              }
+            ],
+            "datasource": "$datasource",
+            "fontSize": "100%",
+            "id": 8,
+            "links": [],
+            "minSpan": 4,
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+              "col": 1,
+              "desc": true
+            },
+            "span": 4,
+            "styles": [
+              {
+                "colorMode": "cell",
+                "colors": [
+                  "rgba(50, 172, 45, 0.97)",
+                  "rgba(237, 129, 40, 0.89)",
+                  "rgba(245, 54, 54, 0.9)"
+                ],
+                "decimals": 2,
+                "pattern": "/.*/",
+                "thresholds": [
+                  "80",
+                  "90"
+                ],
+                "type": "number",
+                "unit": "percent"
+              }
+            ],
+            "targets": [
+              {
+                "expr": "sum(100 - ((cluster_namespace_controller_pod_container:spec_memory_limit_bytes{container_name!=\"POD\",pod_name=~\"$pod\"} - cluster_namespace_controller_pod_container:memory_usage:bytes{container_name!=\"POD\",pod_name=~\"$pod\"})  * 100 / cluster_namespace_controller_pod_container:spec_memory_limit_bytes{container_name!=\"POD\",pod_name=~\"$pod\"}) ) by (pod_name) ",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "{{pod_name}}",
+                "refId": "A",
+                "step": 4
+              }
+            ],
+            "title": "Memory usage (in percent of limit)",
+            "transform": "timeseries_aggregations",
+            "type": "table"
+          },
+          {
+            "columns": [
+              {
+                "text": "Current",
+                "value": "current"
+              }
+            ],
+            "datasource": "$datasource",
+            "fontSize": "100%",
+            "id": 9,
+            "links": [],
+            "minSpan": 4,
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+              "col": 0,
+              "desc": true
+            },
+            "span": 4,
+            "styles": [
+              {
+                "colorMode": "cell",
+                "colors": [
+                  "rgba(245, 54, 54, 0.9)",
+                  "rgba(237, 129, 40, 0.89)",
+                  "rgba(50, 172, 45, 0.97)"
+                ],
+                "decimals": 2,
+                "pattern": "/.*/",
+                "thresholds": [
+                  "0",
+                  "0",
+                  "1"
+                ],
+                "type": "number",
+                "unit": "short"
+              }
+            ],
+            "targets": [
+              {
+                "expr": "cluster_namespace_controller_pod_container:memory_oom:rate{container_name!=\"POD\", pod_name=~\"$pod\"}",
+                "intervalFactor": 2,
+                "legendFormat": "{{ container_name  }}",
+                "refId": "A",
+                "step": 4
+              }
+            ],
+            "title": "Out-of-memory",
+            "transform": "timeseries_aggregations",
+            "type": "table"
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "Memory",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 250,
+        "panels": [
+          {
+            "columns": [
+              {
+                "text": "Current",
+                "value": "current"
+              }
+            ],
+            "datasource": "$datasource",
+            "fontSize": "100%",
+            "id": 10,
+            "links": [],
+            "pageSize": 5,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+              "col": 1,
+              "desc": true
+            },
+            "span": 12,
+            "styles": [
+              {
+                "colorMode": "cell",
+                "colors": [
+                  "rgba(50, 172, 45, 0.97)",
+                  "rgba(237, 129, 40, 0.89)",
+                  "rgba(245, 54, 54, 0.9)"
+                ],
+                "decimals": 2,
+                "pattern": "/.*/",
+                "thresholds": [
+                  "80",
+                  "90"
+                ],
+                "type": "number",
+                "unit": "percent"
+              }
+            ],
+            "targets": [
+              {
+                "expr": "sum(cluster_namespace_controller_pod_container:cpu_usage:rate{container_name!=\"POD\",pod=~\"$pod\"}) by (pod) / (sum(kube_pod_container_resource_limits_cpu_cores{namespace=\"monitoring\",pod=~\"$pod\"}) by (pod) / 100) /10",
+                "intervalFactor": 2,
+                "legendFormat": " {{ pod }}",
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "title": "CPU Usage (in percent of limit)",
+            "transform": "timeseries_aggregations",
+            "type": "table"
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [
+      "kubernetes"
+    ],
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "text": "prometheus",
+            "value": "prometheus"
+          },
+          "hide": 2,
+          "label": "",
+          "name": "datasource",
+          "options": [],
+          "query": "prometheus",
+          "refresh": 1,
+          "regex": "",
+          "type": "datasource"
         },
-        "hide": 0,
-        "label": "Interval",
-        "name": "interval",
-        "options": [
-          {
-            "selected": false,
-            "text": "auto",
-            "value": "$__auto_interval"
-          },
-          {
-            "selected": false,
-            "text": "30s",
-            "value": "30s"
-          },
-          {
-            "selected": false,
-            "text": "1m",
-            "value": "1m"
-          },
-          {
-            "selected": false,
-            "text": "2m",
-            "value": "2m"
-          },
-          {
-            "selected": true,
+        {
+          "auto": true,
+          "auto_count": 30,
+          "auto_min": "30s",
+          "current": {
             "text": "3m",
             "value": "3m"
           },
-          {
-            "selected": false,
-            "text": "5m",
-            "value": "5m"
-          },
-          {
-            "selected": false,
-            "text": "7m",
-            "value": "7m"
-          },
-          {
-            "selected": false,
-            "text": "10m",
-            "value": "10m"
-          },
-          {
-            "selected": false,
-            "text": "30m",
-            "value": "30m"
-          },
-          {
-            "selected": false,
-            "text": "1h",
-            "value": "1h"
-          },
-          {
-            "selected": false,
-            "text": "6h",
-            "value": "6h"
-          },
-          {
-            "selected": false,
-            "text": "12h",
-            "value": "12h"
-          },
-          {
-            "selected": false,
-            "text": "1d",
-            "value": "1d"
-          },
-          {
-            "selected": false,
-            "text": "7d",
-            "value": "7d"
-          },
-          {
-            "selected": false,
-            "text": "14d",
-            "value": "14d"
-          },
-          {
-            "selected": false,
-            "text": "30d",
-            "value": "30d"
-          }
-        ],
-        "query": "30s,1m,2m,3m,5m,7m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
-        "refresh": 2,
-        "type": "interval"
-      },
-      {
-        "allValue": null,
-        "current": {
-          "text": "All",
-          "value": "$__all"
+          "hide": 0,
+          "label": "Interval",
+          "name": "interval",
+          "options": [
+            {
+              "selected": false,
+              "text": "auto",
+              "value": "$__auto_interval"
+            },
+            {
+              "selected": false,
+              "text": "30s",
+              "value": "30s"
+            },
+            {
+              "selected": false,
+              "text": "1m",
+              "value": "1m"
+            },
+            {
+              "selected": false,
+              "text": "2m",
+              "value": "2m"
+            },
+            {
+              "selected": true,
+              "text": "3m",
+              "value": "3m"
+            },
+            {
+              "selected": false,
+              "text": "5m",
+              "value": "5m"
+            },
+            {
+              "selected": false,
+              "text": "7m",
+              "value": "7m"
+            },
+            {
+              "selected": false,
+              "text": "10m",
+              "value": "10m"
+            },
+            {
+              "selected": false,
+              "text": "30m",
+              "value": "30m"
+            },
+            {
+              "selected": false,
+              "text": "1h",
+              "value": "1h"
+            },
+            {
+              "selected": false,
+              "text": "6h",
+              "value": "6h"
+            },
+            {
+              "selected": false,
+              "text": "12h",
+              "value": "12h"
+            },
+            {
+              "selected": false,
+              "text": "1d",
+              "value": "1d"
+            },
+            {
+              "selected": false,
+              "text": "7d",
+              "value": "7d"
+            },
+            {
+              "selected": false,
+              "text": "14d",
+              "value": "14d"
+            },
+            {
+              "selected": false,
+              "text": "30d",
+              "value": "30d"
+            }
+          ],
+          "query": "30s,1m,2m,3m,5m,7m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+          "refresh": 2,
+          "type": "interval"
         },
-        "datasource": "$datasource",
-        "hide": 0,
-        "includeAll": true,
-        "label": null,
-        "multi": false,
-        "name": "namespace",
-        "options": [],
-        "query": "label_values(kube_pod_info, namespace)",
-        "refresh": 1,
-        "regex": "",
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": null,
-        "current": {
-          "text": "All",
-          "value": "$__all"
+        {
+          "allValue": null,
+          "current": {
+            "text": "monitoring",
+            "value": "monitoring"
+          },
+          "datasource": "$datasource",
+          "hide": 0,
+          "includeAll": true,
+          "label": null,
+          "multi": false,
+          "name": "namespace",
+          "options": [],
+          "query": "label_values(kube_pod_info, namespace)",
+          "refresh": 1,
+          "regex": "",
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
         },
-        "datasource": "$datasource",
-        "hide": 0,
-        "includeAll": true,
-        "label": null,
-        "multi": false,
-        "name": "pod",
-        "options": [],
-        "query": "label_values(kube_pod_info{namespace=~\"$namespace\"}, pod)",
-        "refresh": 1,
-        "regex": "",
-        "sort": 1,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      }
-    ]
+        {
+          "allValue": null,
+          "current": {
+            "tags": [],
+            "text": "prometheus-k8s-0",
+            "value": "prometheus-k8s-0"
+          },
+          "datasource": "$datasource",
+          "hide": 0,
+          "includeAll": true,
+          "label": null,
+          "multi": false,
+          "name": "pod",
+          "options": [],
+          "query": "label_values(kube_pod_info{namespace=~\"$namespace\"}, pod)",
+          "refresh": 1,
+          "regex": "",
+          "sort": 1,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "time": {
+      "from": "now-30m",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "browser",
+    "title": "Kubernetes Pod",
+    "version": 7
   },
-  "time": {
-    "from": "now-30m",
-    "to": "now"
-  },
-  "timepicker": {
-    "refresh_intervals": [
-      "5s",
-      "10s",
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
-    "time_options": [
-      "5m",
-      "15m",
-      "1h",
-      "6h",
-      "12h",
-      "24h",
-      "2d",
-      "7d",
-      "30d"
-    ]
-  },
-  "timezone": "browser",
-  "title": "Kubernetes Pod",
-  "version": 154
-}
-,
   "inputs": [
     {
       "name": "DS_PROMETHEUS",

--- a/contrib/kube-prometheus/assets/prometheus/rules/kubernetes.rules
+++ b/contrib/kube-prometheus/assets/prometheus/rules/kubernetes.rules
@@ -21,13 +21,13 @@ cluster_namespace_controller_pod_container:spec_cpu_shares =
   )
 
 cluster_namespace_controller_pod_container:cpu_usage:rate =
-  sum by (cluster,namespace,controller,pod_name,container_name) (
+  sum by (cluster,namespace,pod,pod_name,container_name) (
     label_replace(
       irate(
         container_cpu_usage_seconds_total{container_name!=""}[5m]
       ),
-      "controller", "$1",
-      "pod_name", "^(.*)-[a-z0-9]+"
+      "pod", "$1",
+      "pod_name", "^(.*)"
     )
   )
 

--- a/contrib/kube-prometheus/manifests/grafana/grafana-dashboards.yaml
+++ b/contrib/kube-prometheus/manifests/grafana/grafana-dashboards.yaml
@@ -12,7 +12,15 @@ data:
       "gnetId": null,
       "graphTooltip": 1,
       "hideControls": false,
+<<<<<<< Updated upstream
       "id": null,
+<<<<<<< HEAD
+=======
+      "links": [],
+      "refresh": false,
+=======
+      "id": 1,
+>>>>>>> Add CPU limit percent
       "links": [
         {
           "asDropdown": true,
@@ -27,6 +35,10 @@ data:
         }
       ],
       "refresh": "30s",
+<<<<<<< HEAD
+=======
+>>>>>>> Stashed changes
+>>>>>>> Add CPU limit percent
       "rows": [
         {
           "collapse": false,
@@ -96,9 +108,18 @@ data:
                   "legendFormat": "",
                   "metric": "",
                   "refId": "A",
+<<<<<<< HEAD
                   "step": 40,
                   "target": "sumSeries(snap.$cluster.grafanalabs.kubestate.node.$node.status.capacity.pods)",
                   "textEditor": false
+=======
+<<<<<<< Updated upstream
+                  "step": 50
+=======
+                  "step": 40,
+                  "textEditor": false
+>>>>>>> Stashed changes
+>>>>>>> Add CPU limit percent
                 }
               ],
               "thresholds": "80,90",
@@ -140,9 +161,30 @@ data:
               "mappingType": 1,
               "mappingTypes": [
                 {
+<<<<<<< HEAD
                   "name": "value to text",
                   "value": 1
+=======
+                  "expr": "sum(node_load1)",
+                  "intervalFactor": 4,
+                  "legendFormat": "load 1m",
+                  "refId": "A",
+<<<<<<< Updated upstream
+                  "step": 20,
+                  "target": ""
+>>>>>>> Add CPU limit percent
                 },
+=======
+                  "step": 40,
+                  "textEditor": false
+                }
+              ],
+              "thresholds": "80,90",
+              "title": "Cluster CPU Usage",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+>>>>>>> Stashed changes
                 {
                   "name": "range to text",
                   "value": 2
@@ -255,9 +297,49 @@ data:
                   "hide": false,
                   "intervalFactor": 2,
                   "refId": "A",
+<<<<<<< HEAD
                   "step": 40,
                   "target": "sumSeries(snap.$cluster.grafanalabs.kubestate.node.$node.status.capacity.memory.bytes)",
                   "textEditor": false
+=======
+<<<<<<< Updated upstream
+                  "step": 4,
+                  "target": ""
+                },
+                {
+                  "expr": "sum(node_memory_Buffers)",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "memory buffers",
+                  "metric": "memo",
+                  "refId": "B",
+                  "step": 4,
+                  "target": ""
+                },
+                {
+                  "expr": "sum(node_memory_Cached)",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "memory cached",
+                  "metric": "memo",
+                  "refId": "C",
+                  "step": 4,
+                  "target": ""
+                },
+                {
+                  "expr": "sum(node_memory_MemFree)",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "memory free",
+                  "metric": "memo",
+                  "refId": "D",
+                  "step": 4,
+                  "target": ""
+=======
+                  "step": 40,
+                  "textEditor": false
+>>>>>>> Stashed changes
+>>>>>>> Add CPU limit percent
                 }
               ],
               "thresholds": "80,90",
@@ -335,9 +417,19 @@ data:
                   "intervalFactor": 2,
                   "legendFormat": "",
                   "refId": "A",
+<<<<<<< HEAD
                   "step": 40,
                   "target": "sumSeries(snap.$cluster.$node.intel.docker.kube-system.*.snap.stats.filesystem.*.capacity)",
                   "textEditor": false
+=======
+<<<<<<< Updated upstream
+                  "step": 60,
+                  "target": ""
+=======
+                  "step": 40,
+                  "textEditor": false
+>>>>>>> Stashed changes
+>>>>>>> Add CPU limit percent
                 }
               ],
               "thresholds": "80,90",
@@ -391,17 +483,35 @@ data:
                   "intervalFactor": 2,
                   "legendFormat": "Allocatable",
                   "refId": "A",
+<<<<<<< HEAD
                   "step": 10,
                   "target": "alias(sumSeries(snap.$cluster.grafanalabs.kubestate.node.$node.status.capacity.pods), 'Capacity')",
                   "textEditor": false
+=======
+<<<<<<< Updated upstream
+                  "step": 8,
+                  "target": ""
+=======
+                  "step": 10,
+                  "textEditor": false
+>>>>>>> Stashed changes
+>>>>>>> Add CPU limit percent
                 },
                 {
                   "expr": "sum(kube_node_status_capacity_pods)",
                   "intervalFactor": 2,
                   "legendFormat": "Capacity",
                   "refId": "B",
+<<<<<<< HEAD
                   "step": 10,
                   "target": "alias(sumSeries(snap.$cluster.grafanalabs.kubestate.node.$node.status.allocatable.pods), 'Allocatable')"
+=======
+<<<<<<< Updated upstream
+                  "step": 8
+=======
+                  "step": 10
+>>>>>>> Stashed changes
+>>>>>>> Add CPU limit percent
                 },
                 {
                   "expr": "sum(kube_pod_status_scheduled)",
@@ -485,9 +595,26 @@ data:
                   "intervalFactor": 2,
                   "legendFormat": "Used",
                   "refId": "A",
+<<<<<<< HEAD
                   "step": 10,
                   "target": "alias(sumSeries(snap.$cluster.grafanalabs.kubestate.node.$node.status.capacity.cpu.cores), 'Capacity')"
                 },
+=======
+<<<<<<< Updated upstream
+                  "step": 60,
+                  "target": ""
+                }
+              ],
+              "thresholds": "0.75, 0.9",
+              "title": "Disk space usage",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+=======
+                  "step": 10
+                },
+>>>>>>> Stashed changes
+>>>>>>> Add CPU limit percent
                 {
                   "expr": "sum(machine_cpu_cores)",
                   "intervalFactor": 2,
@@ -567,7 +694,25 @@ data:
               "steppedLine": false,
               "targets": [
                 {
+<<<<<<< HEAD
                   "expr": "sum(cluster_namespace_controller_pod_container:memory_usage:bytes)",
+=======
+<<<<<<< Updated upstream
+                  "expr": "sum(rate(node_network_receive_bytes{device!~\"lo\"}[5m]))",
+=======
+                  "expr": "sum(cluster_namespace_controller_pod_container:memory_usage:bytes)",
+                  "hide": false,
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "Used",
+                  "refId": "C",
+                  "step": 10,
+                  "textEditor": false
+                },
+                {
+                  "expr": "sum(machine_memory_bytes)",
+>>>>>>> Stashed changes
+>>>>>>> Add CPU limit percent
                   "hide": false,
                   "interval": "",
                   "intervalFactor": 2,
@@ -657,7 +802,23 @@ data:
               "steppedLine": false,
               "targets": [
                 {
+<<<<<<< HEAD
                   "expr": "sum(node_filesystem_size{device!=\"rootfs\",job=\"node-exporter\"}) - sum(node_filesystem_free{device!=\"rootfs\",job=\"node-exporter\"})",
+=======
+<<<<<<< Updated upstream
+                  "expr": "sum(rate(node_network_transmit_bytes{device!~\"lo\"}[5m]))",
+=======
+                  "expr": "sum(node_filesystem_size{device!=\"rootfs\",job=\"node-exporter\"}) - sum(node_filesystem_free{device!=\"rootfs\",job=\"node-exporter\"})",
+                  "hide": false,
+                  "intervalFactor": 2,
+                  "legendFormat": "Usage",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "sum(node_filesystem_size{device!=\"rootfs\",job=\"node-exporter\"})",
+>>>>>>> Stashed changes
+>>>>>>> Add CPU limit percent
                   "hide": false,
                   "intervalFactor": 2,
                   "legendFormat": "Usage",
@@ -729,11 +890,15 @@ data:
                   "value": "current"
                 }
               ],
+<<<<<<< HEAD
               "datasource": "$datasource",
               "editable": true,
               "error": false,
               "fontSize": "100%",
               "id": 30,
+=======
+<<<<<<< Updated upstream
+>>>>>>> Add CPU limit percent
               "links": [],
               "pageSize": 6,
               "scroll": true,
@@ -751,6 +916,28 @@ data:
                   "type": "date"
                 },
                 {
+<<<<<<< HEAD
+=======
+                  "name": "range to text",
+                  "value": 2
+=======
+              "datasource": "$datasource",
+              "editable": true,
+              "error": false,
+              "fontSize": "80%",
+              "id": 30,
+              "links": [],
+              "pageSize": 8,
+              "scroll": true,
+              "showHeader": true,
+              "sort": {
+                "col": 1,
+                "desc": false
+              },
+              "span": 3,
+              "styles": [
+                {
+>>>>>>> Add CPU limit percent
                   "colorMode": "row",
                   "colors": [
                     "rgba(245, 54, 54, 0.9)",
@@ -765,18 +952,35 @@ data:
                   ],
                   "type": "number",
                   "unit": "short"
+<<<<<<< HEAD
+=======
+>>>>>>> Stashed changes
+>>>>>>> Add CPU limit percent
                 }
               ],
               "targets": [
                 {
+<<<<<<< HEAD
+=======
+<<<<<<< Updated upstream
+                  "from": "null",
+                  "to": "null",
+                  "text": "N/A"
+=======
+>>>>>>> Add CPU limit percent
                   "expr": "sum(kube_deployment_status_replicas_unavailable{job=\"kube-state-metrics\"}) by (deployment) < BOOL sum(kube_deployment_status_replicas_updated{job=\"kube-state-metrics\"}) by (deployment)",
                   "hide": false,
                   "interval": "",
                   "intervalFactor": 2,
                   "legendFormat": "{{ deployment }}",
                   "refId": "B",
+<<<<<<< HEAD
                   "step": 10,
                   "target": "aliasByNode(snap.$cluster.grafanalabs.kubestate.deployment.$namespace.*.status.updatedreplicas, 6)"
+=======
+                  "step": 10
+>>>>>>> Stashed changes
+>>>>>>> Add CPU limit percent
                 }
               ],
               "title": "Deployment Replicas - up-to-date",
@@ -841,11 +1045,22 @@ data:
               },
               "targets": [
                 {
+<<<<<<< HEAD
                   "expr": "sum(kube_deployment_status_replicas_available{job=\"kube-state-metrics\"}) + sum(kube_deployment_status_replicas_unavailable{job=\"kube-state-metrics\"})",
                   "intervalFactor": 2,
                   "refId": "A",
                   "step": 40,
                   "target": "sumSeries(snap.$cluster.grafanalabs.kubestate.deployment.$namespace.*.spec.desiredreplicas)"
+=======
+                  "refId": "A",
+<<<<<<< Updated upstream
+                  "expr": "sum(rate(container_network_transmit_bytes_total{namespace=\"$deployment_namespace\",pod_name=~\"$deployment_name.*\"}[3m])) + sum(rate(container_network_receive_bytes_total{namespace=\"$deployment_namespace\",pod_name=~\"$deployment_name.*\"}[3m])) ",
+                  "intervalFactor": 2,
+                  "step": 600
+=======
+                  "step": 40
+>>>>>>> Stashed changes
+>>>>>>> Add CPU limit percent
                 }
               ],
               "thresholds": "",
@@ -918,11 +1133,22 @@ data:
               },
               "targets": [
                 {
+<<<<<<< HEAD
                   "expr": "sum(kube_deployment_status_replicas_updated{job=\"kube-state-metrics\"})",
                   "intervalFactor": 2,
                   "refId": "A",
                   "step": 40,
                   "target": "sumSeries(snap.$cluster.grafanalabs.kubestate.deployment.$namespace.*.status.updatedreplicas)"
+=======
+                  "refId": "A",
+<<<<<<< Updated upstream
+                  "expr": "kube_deployment_status_replicas_available{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+                  "intervalFactor": 2,
+                  "step": 600
+=======
+                  "step": 40
+>>>>>>> Stashed changes
+>>>>>>> Add CPU limit percent
                 }
               ],
               "thresholds": "",
@@ -998,8 +1224,16 @@ data:
                   "expr": "sum(kube_deployment_status_replicas_unavailable{job=\"kube-state-metrics\"})",
                   "intervalFactor": 2,
                   "refId": "A",
+<<<<<<< HEAD
                   "step": 40,
                   "target": "sumSeries(snap.$cluster.grafanalabs.kubestate.deployment.$namespace.*.status.unavailablereplicas)"
+=======
+<<<<<<< Updated upstream
+                  "step": 600
+=======
+                  "step": 40
+>>>>>>> Stashed changes
+>>>>>>> Add CPU limit percent
                 }
               ],
               "thresholds": "",
@@ -1088,9 +1322,18 @@ data:
                   "expr": "sum(kube_node_status_ready{job=\"kube-state-metrics\",condition=\"true\"}) - sum(kube_pod_status_ready{job=\"kube-state-metrics\",pod=~\"kube-apiserver-.*\"})",
                   "intervalFactor": 2,
                   "refId": "A",
+<<<<<<< HEAD
                   "step": 40,
                   "target": "countSeries(snap.$cluster.grafanalabs.kubestate.node.$node.status.outofdisk)",
                   "textEditor": false
+=======
+<<<<<<< Updated upstream
+                  "step": 600
+=======
+                  "step": 40,
+                  "textEditor": false
+>>>>>>> Stashed changes
+>>>>>>> Add CPU limit percent
                 }
               ],
               "thresholds": "",
@@ -1126,6 +1369,7 @@ data:
                 "thresholdLabels": false,
                 "thresholdMarkers": true
               },
+<<<<<<< HEAD
               "id": 8,
               "interval": null,
               "links": [],
@@ -1860,6 +2104,23 @@ data:
               },
               "id": 23,
               "interval": null,
+=======
+<<<<<<< Updated upstream
+              "id": 1,
+              "isNew": true,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false,
+                "hideZero": false
+=======
+              "id": 8,
+              "interval": null,
+>>>>>>> Add CPU limit percent
               "links": [],
               "mappingType": 1,
               "mappingTypes": [
@@ -1886,11 +2147,16 @@ data:
                   "to": "null"
                 }
               ],
+<<<<<<< HEAD
               "span": 3,
+=======
+              "span": 4,
+>>>>>>> Add CPU limit percent
               "sparkline": {
                 "fillColor": "rgba(31, 118, 189, 0.18)",
                 "full": false,
                 "lineColor": "rgb(31, 120, 193)",
+<<<<<<< HEAD
                 "show": true
               },
               "targets": [
@@ -1989,6 +2255,25 @@ data:
               "valueFontSize": "80%",
               "valueMaps": [
                 {
+=======
+                "show": false
+              },
+              "targets": [
+                {
+                  "expr": "sum(kube_node_status_out_of_disk{condition=\"true\", job=\"kube-state-metrics\"})",
+                  "intervalFactor": 2,
+                  "refId": "A",
+                  "step": 40,
+                  "textEditor": false
+                }
+              ],
+              "thresholds": "1,1",
+              "title": "Nodes Out of Disk",
+              "type": "singlestat",
+              "valueFontSize": "100%",
+              "valueMaps": [
+                {
+>>>>>>> Add CPU limit percent
                   "op": "=",
                   "text": "N/A",
                   "value": "null"
@@ -1998,6 +2283,7 @@ data:
             },
             {
               "cacheTimeout": null,
+<<<<<<< HEAD
               "colorBackground": false,
               "colorValue": false,
               "colors": [
@@ -2007,6 +2293,16 @@ data:
               ],
               "datasource": "$datasource",
               "decimals": null,
+=======
+              "colorBackground": true,
+              "colorValue": false,
+              "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(245, 54, 54, 0.9)"
+              ],
+              "datasource": "$datasource",
+>>>>>>> Add CPU limit percent
               "editable": true,
               "error": false,
               "format": "none",
@@ -2017,11 +2313,16 @@ data:
                 "thresholdLabels": false,
                 "thresholdMarkers": true
               },
+<<<<<<< HEAD
               "id": 19,
+=======
+              "id": 13,
+>>>>>>> Add CPU limit percent
               "interval": null,
               "links": [],
               "mappingType": 1,
               "mappingTypes": [
+<<<<<<< HEAD
                 {
                   "name": "value to text",
                   "value": 1
@@ -2102,6 +2403,9 @@ data:
               "mappingType": 1,
               "mappingTypes": [
                 {
+=======
+                {
+>>>>>>> Add CPU limit percent
                   "name": "value to text",
                   "value": 1
                 },
@@ -2124,11 +2428,16 @@ data:
                   "to": "null"
                 }
               ],
+<<<<<<< HEAD
               "span": 6,
+=======
+              "span": 4,
+>>>>>>> Add CPU limit percent
               "sparkline": {
                 "fillColor": "rgba(31, 118, 189, 0.18)",
                 "full": false,
                 "lineColor": "rgb(31, 120, 193)",
+<<<<<<< HEAD
                 "show": true
               },
               "targets": [
@@ -2145,6 +2454,23 @@ data:
               "title": "Memory Requested By Containers",
               "type": "singlestat",
               "valueFontSize": "80%",
+=======
+                "show": false
+              },
+              "targets": [
+                {
+                  "expr": "sum(kube_node_spec_unschedulable) - sum(kube_pod_status_ready{job=\"kube-state-metrics\",pod=~\"kube-apiserver-.*\"})",
+                  "intervalFactor": 2,
+                  "refId": "A",
+                  "step": 40,
+                  "textEditor": false
+                }
+              ],
+              "thresholds": "1",
+              "title": "Unschedulable Nodes",
+              "type": "singlestat",
+              "valueFontSize": "100%",
+>>>>>>> Add CPU limit percent
               "valueMaps": [
                 {
                   "op": "=",
@@ -2159,6 +2485,7 @@ data:
           "repeatIteration": null,
           "repeatRowId": null,
           "showTitle": true,
+<<<<<<< HEAD
           "title": "Containers",
           "titleSize": "h3"
         }
@@ -2188,6 +2515,874 @@ data:
       },
       "time": {
         "from": "now-30m",
+=======
+          "title": "Nodes",
+          "titleSize": "h3"
+        },
+        {
+          "collapse": false,
+          "height": "120",
+          "panels": [
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(187, 194, 208, 0.97)"
+              ],
+              "datasource": "$datasource",
+              "decimals": 0,
+              "editable": true,
+              "error": false,
+              "format": "none",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 9,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "span": 6,
+              "sparkline": {
+                "fillColor": "rgba(31, 189, 41, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 200, 32)",
+                "show": true
+              },
+              "targets": [
+                {
+                  "expr": "sum(kube_pod_status_ready{job=\"kube-state-metrics\"})",
+                  "intervalFactor": 2,
+                  "refId": "A",
+                  "step": 40,
+                  "textEditor": false
+                }
+              ],
+              "thresholds": "",
+              "title": "Pods Running",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "rgba(187, 194, 208, 0.97)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(245, 54, 54, 0.9)"
+              ],
+              "datasource": "$datasource",
+              "decimals": 0,
+              "editable": true,
+              "error": false,
+              "format": "none",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 31,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "span": 6,
+              "sparkline": {
+                "fillColor": "rgba(31, 189, 41, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 200, 32)",
+                "show": true
+              },
+              "targets": [
+                {
+                  "expr": "sum(kube_pod_status_scheduled{condition=\"true\",job=\"kube-state-metrics\"}) - sum(kube_pod_status_ready{job=\"kube-state-metrics\"})",
+                  "intervalFactor": 2,
+                  "refId": "A",
+                  "step": 40,
+                  "textEditor": false
+                }
+              ],
+              "thresholds": "0,5,20",
+              "title": "Pods Pending",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": true,
+              "colors": [
+                "rgba(187, 194, 208, 0.97)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(245, 54, 54, 0.9)"
+              ],
+              "datasource": "$datasource",
+              "decimals": 0,
+              "editable": true,
+              "error": false,
+              "format": "none",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 33,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "span": 4,
+              "sparkline": {
+                "fillColor": "rgba(31, 189, 41, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 200, 32)",
+                "show": true
+              },
+              "targets": [
+                {
+                  "expr": "sum(kube_pod_status_phase{job=\"kube-state-metrics\",phase=\"Failed\"})",
+                  "intervalFactor": 2,
+                  "refId": "A",
+                  "step": 40,
+                  "textEditor": false
+                }
+              ],
+              "thresholds": "0,5,20",
+              "title": "Pods Failed",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "0",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(187, 194, 208, 0.97)"
+              ],
+              "datasource": "$datasource",
+              "decimals": 0,
+              "editable": true,
+              "error": false,
+              "format": "none",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 34,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "span": 4,
+              "sparkline": {
+                "fillColor": "rgba(31, 189, 41, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 200, 32)",
+                "show": true
+              },
+              "targets": [
+                {
+                  "expr": "sum(kube_pod_status_phase{job=\"kube-state-metrics\",phase=\"Succeeded\"})",
+                  "intervalFactor": 2,
+                  "refId": "A",
+                  "step": 40,
+                  "textEditor": false
+                }
+              ],
+              "thresholds": "",
+              "title": "Pods Succeeded",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "0",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(187, 194, 208, 0.97)"
+              ],
+              "datasource": "$datasource",
+              "decimals": 0,
+              "editable": true,
+              "error": false,
+              "format": "none",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 35,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "span": 4,
+              "sparkline": {
+                "fillColor": "rgba(31, 189, 41, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 200, 32)",
+                "show": true
+              },
+              "targets": [
+                {
+                  "expr": "sum(kube_pod_status_phase{job=\"kube-state-metrics\",phase=\"Unknown\"})",
+                  "intervalFactor": 2,
+                  "refId": "A",
+                  "step": 40,
+                  "textEditor": false
+                }
+              ],
+              "thresholds": "",
+              "title": "Pods - Status Unknown",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "0",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Pods",
+          "titleSize": "h3"
+        },
+        {
+          "collapse": false,
+          "height": "125",
+          "panels": [
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "datasource": "$datasource",
+              "decimals": 0,
+              "editable": true,
+              "error": false,
+              "format": "none",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 12,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "span": 3,
+              "sparkline": {
+                "fillColor": "rgba(89, 77, 192, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": true
+              },
+              "targets": [
+                {
+                  "expr": "sum(kube_pod_container_status_running{job=\"kube-state-metrics\"})",
+                  "intervalFactor": 2,
+                  "refId": "A",
+                  "step": 40,
+                  "textEditor": false
+                }
+              ],
+              "thresholds": "",
+              "title": "Containers Running",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "datasource": "$datasource",
+              "editable": true,
+              "error": false,
+              "format": "none",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 11,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "span": 3,
+              "sparkline": {
+                "fillColor": "rgba(31, 41, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": true
+              },
+              "targets": [
+                {
+                  "expr": "sum(kube_pod_container_status_waiting{job=\"kube-state-metrics\"})",
+                  "intervalFactor": 2,
+                  "refId": "A",
+                  "step": 40
+                }
+              ],
+              "thresholds": "",
+              "title": "Containers Waiting",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "datasource": "$datasource",
+              "decimals": 0,
+              "editable": true,
+              "error": false,
+              "format": "none",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 23,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "span": 3,
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": true
+              },
+              "targets": [
+                {
+                  "expr": "sum(kube_pod_container_status_terminated{job=\"kube-state-metrics\"})",
+                  "intervalFactor": 2,
+                  "refId": "A",
+                  "step": 40
+                }
+              ],
+              "thresholds": "",
+              "title": "Containers Terminated",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "datasource": "$datasource",
+              "decimals": 0,
+              "editable": true,
+              "error": false,
+              "format": "none",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+>>>>>>> Stashed changes
+              },
+              "lines": true,
+              "linewidth": 2,
+              "links": [],
+              "nullPointMode": "connected",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "span": 12,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "kube_deployment_status_replicas{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+                  "intervalFactor": 2,
+                  "legendFormat": "current replicas",
+                  "refId": "A",
+<<<<<<< Updated upstream
+                  "step": 30
+=======
+                  "step": 40
+                }
+              ],
+              "thresholds": "",
+              "timeFrom": null,
+              "title": "Container Restarts",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "datasource": "$datasource",
+              "decimals": null,
+              "editable": true,
+              "error": false,
+              "format": "none",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 19,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+>>>>>>> Stashed changes
+                },
+                {
+                  "expr": "kube_deployment_status_replicas_available{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+                  "intervalFactor": 2,
+<<<<<<< Updated upstream
+                  "legendFormat": "available",
+                  "refId": "B",
+                  "step": 30
+                },
+=======
+                  "refId": "A",
+                  "step": 40,
+                  "textEditor": false
+                }
+              ],
+              "thresholds": "",
+              "title": "CPU Cores Requested by Containers",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "datasource": "$datasource",
+              "decimals": null,
+              "editable": true,
+              "error": false,
+              "format": "decbytes",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "id": 20,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+>>>>>>> Stashed changes
+                {
+                  "expr": "kube_deployment_status_replicas_unavailable{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+                  "intervalFactor": 2,
+                  "legendFormat": "unavailable",
+                  "refId": "C",
+                  "step": 30
+                },
+                {
+                  "expr": "kube_deployment_status_replicas_updated{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+                  "intervalFactor": 2,
+                  "legendFormat": "updated",
+                  "refId": "D",
+                  "step": 30
+                },
+                {
+                  "expr": "kube_deployment_spec_replicas{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
+                  "intervalFactor": 2,
+                  "legendFormat": "desired",
+                  "refId": "E",
+                  "step": 30
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Replicas",
+              "tooltip": {
+                "msResolution": true,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+              },
+              "type": "graph",
+              "xaxis": {
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+<<<<<<< Updated upstream
+                  "format": "none",
+                  "label": "",
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+=======
+                  "expr": "sum(kube_pod_container_resource_requests_memory_bytes)",
+                  "intervalFactor": 2,
+                  "refId": "A",
+                  "step": 40,
+                  "textEditor": false
+                }
+              ],
+              "thresholds": "",
+              "title": "Memory Requested By Containers",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+>>>>>>> Stashed changes
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ],
+              "transparent": false
+            }
+          ],
+          "title": "New row",
+          "showTitle": false
+        }
+      ],
+      "time": {
+        "from": "now-6h",
+>>>>>>> Add CPU limit percent
         "to": "now"
       },
       "timepicker": {
@@ -2215,9 +3410,59 @@ data:
           "30d"
         ]
       },
+<<<<<<< HEAD
       "timezone": "browser",
       "title": "Kubernetes Cluster",
       "version": 84
+=======
+<<<<<<< Updated upstream
+      "templating": {
+        "list": [
+          {
+            "allValue": ".*",
+            "current": {},
+            "datasource": "${DS_PROMETHEUS}",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Namespace",
+            "multi": false,
+            "name": "deployment_namespace",
+            "options": [],
+            "query": "label_values(kube_deployment_metadata_generation, namespace)",
+            "refresh": 1,
+            "regex": "",
+            "sort": 0,
+            "tagValuesQuery": null,
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {},
+            "datasource": "${DS_PROMETHEUS}",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Deployment",
+            "multi": false,
+            "name": "deployment_name",
+            "options": [],
+            "query": "label_values(kube_deployment_metadata_generation{namespace=\"$deployment_namespace\"}, deployment)",
+            "refresh": 1,
+            "regex": "",
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "deployment",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+=======
+      "timezone": "browser",
+      "title": "Kubernetes Cluster",
+      "version": 6
+>>>>>>> Add CPU limit percent
     }
     ,
       "inputs": [
@@ -2234,6 +3479,10 @@ data:
     {
       "dashboard":
     {
+<<<<<<< HEAD
+=======
+>>>>>>> Stashed changes
+>>>>>>> Add CPU limit percent
       "annotations": {
         "list": []
       },

--- a/contrib/kube-prometheus/manifests/grafana/grafana-dashboards.yaml
+++ b/contrib/kube-prometheus/manifests/grafana/grafana-dashboards.yaml
@@ -12,15 +12,7 @@ data:
       "gnetId": null,
       "graphTooltip": 1,
       "hideControls": false,
-<<<<<<< Updated upstream
       "id": null,
-<<<<<<< HEAD
-=======
-      "links": [],
-      "refresh": false,
-=======
-      "id": 1,
->>>>>>> Add CPU limit percent
       "links": [
         {
           "asDropdown": true,
@@ -35,10 +27,6 @@ data:
         }
       ],
       "refresh": "30s",
-<<<<<<< HEAD
-=======
->>>>>>> Stashed changes
->>>>>>> Add CPU limit percent
       "rows": [
         {
           "collapse": false,
@@ -108,18 +96,8 @@ data:
                   "legendFormat": "",
                   "metric": "",
                   "refId": "A",
-<<<<<<< HEAD
-                  "step": 40,
-                  "target": "sumSeries(snap.$cluster.grafanalabs.kubestate.node.$node.status.capacity.pods)",
-                  "textEditor": false
-=======
-<<<<<<< Updated upstream
-                  "step": 50
-=======
                   "step": 40,
                   "textEditor": false
->>>>>>> Stashed changes
->>>>>>> Add CPU limit percent
                 }
               ],
               "thresholds": "80,90",
@@ -161,30 +139,9 @@ data:
               "mappingType": 1,
               "mappingTypes": [
                 {
-<<<<<<< HEAD
                   "name": "value to text",
                   "value": 1
-=======
-                  "expr": "sum(node_load1)",
-                  "intervalFactor": 4,
-                  "legendFormat": "load 1m",
-                  "refId": "A",
-<<<<<<< Updated upstream
-                  "step": 20,
-                  "target": ""
->>>>>>> Add CPU limit percent
                 },
-=======
-                  "step": 40,
-                  "textEditor": false
-                }
-              ],
-              "thresholds": "80,90",
-              "title": "Cluster CPU Usage",
-              "type": "singlestat",
-              "valueFontSize": "80%",
-              "valueMaps": [
->>>>>>> Stashed changes
                 {
                   "name": "range to text",
                   "value": 2
@@ -219,7 +176,6 @@ data:
                   "legendFormat": "",
                   "refId": "A",
                   "step": 40,
-                  "target": "sumSeries(snap.$cluster.grafanalabs.kubestate.node.$node.status.capacity.cpu.cores)",
                   "textEditor": false
                 }
               ],
@@ -297,49 +253,8 @@ data:
                   "hide": false,
                   "intervalFactor": 2,
                   "refId": "A",
-<<<<<<< HEAD
-                  "step": 40,
-                  "target": "sumSeries(snap.$cluster.grafanalabs.kubestate.node.$node.status.capacity.memory.bytes)",
-                  "textEditor": false
-=======
-<<<<<<< Updated upstream
-                  "step": 4,
-                  "target": ""
-                },
-                {
-                  "expr": "sum(node_memory_Buffers)",
-                  "interval": "",
-                  "intervalFactor": 2,
-                  "legendFormat": "memory buffers",
-                  "metric": "memo",
-                  "refId": "B",
-                  "step": 4,
-                  "target": ""
-                },
-                {
-                  "expr": "sum(node_memory_Cached)",
-                  "interval": "",
-                  "intervalFactor": 2,
-                  "legendFormat": "memory cached",
-                  "metric": "memo",
-                  "refId": "C",
-                  "step": 4,
-                  "target": ""
-                },
-                {
-                  "expr": "sum(node_memory_MemFree)",
-                  "interval": "",
-                  "intervalFactor": 2,
-                  "legendFormat": "memory free",
-                  "metric": "memo",
-                  "refId": "D",
-                  "step": 4,
-                  "target": ""
-=======
                   "step": 40,
                   "textEditor": false
->>>>>>> Stashed changes
->>>>>>> Add CPU limit percent
                 }
               ],
               "thresholds": "80,90",
@@ -417,19 +332,8 @@ data:
                   "intervalFactor": 2,
                   "legendFormat": "",
                   "refId": "A",
-<<<<<<< HEAD
-                  "step": 40,
-                  "target": "sumSeries(snap.$cluster.$node.intel.docker.kube-system.*.snap.stats.filesystem.*.capacity)",
-                  "textEditor": false
-=======
-<<<<<<< Updated upstream
-                  "step": 60,
-                  "target": ""
-=======
                   "step": 40,
                   "textEditor": false
->>>>>>> Stashed changes
->>>>>>> Add CPU limit percent
                 }
               ],
               "thresholds": "80,90",
@@ -483,35 +387,15 @@ data:
                   "intervalFactor": 2,
                   "legendFormat": "Allocatable",
                   "refId": "A",
-<<<<<<< HEAD
-                  "step": 10,
-                  "target": "alias(sumSeries(snap.$cluster.grafanalabs.kubestate.node.$node.status.capacity.pods), 'Capacity')",
-                  "textEditor": false
-=======
-<<<<<<< Updated upstream
-                  "step": 8,
-                  "target": ""
-=======
                   "step": 10,
                   "textEditor": false
->>>>>>> Stashed changes
->>>>>>> Add CPU limit percent
                 },
                 {
                   "expr": "sum(kube_node_status_capacity_pods)",
                   "intervalFactor": 2,
                   "legendFormat": "Capacity",
                   "refId": "B",
-<<<<<<< HEAD
-                  "step": 10,
-                  "target": "alias(sumSeries(snap.$cluster.grafanalabs.kubestate.node.$node.status.allocatable.pods), 'Allocatable')"
-=======
-<<<<<<< Updated upstream
-                  "step": 8
-=======
                   "step": 10
->>>>>>> Stashed changes
->>>>>>> Add CPU limit percent
                 },
                 {
                   "expr": "sum(kube_pod_status_scheduled)",
@@ -595,26 +479,8 @@ data:
                   "intervalFactor": 2,
                   "legendFormat": "Used",
                   "refId": "A",
-<<<<<<< HEAD
-                  "step": 10,
-                  "target": "alias(sumSeries(snap.$cluster.grafanalabs.kubestate.node.$node.status.capacity.cpu.cores), 'Capacity')"
-                },
-=======
-<<<<<<< Updated upstream
-                  "step": 60,
-                  "target": ""
-                }
-              ],
-              "thresholds": "0.75, 0.9",
-              "title": "Disk space usage",
-              "type": "singlestat",
-              "valueFontSize": "80%",
-              "valueMaps": [
-=======
                   "step": 10
                 },
->>>>>>> Stashed changes
->>>>>>> Add CPU limit percent
                 {
                   "expr": "sum(machine_cpu_cores)",
                   "intervalFactor": 2,
@@ -694,12 +560,6 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-<<<<<<< HEAD
-                  "expr": "sum(cluster_namespace_controller_pod_container:memory_usage:bytes)",
-=======
-<<<<<<< Updated upstream
-                  "expr": "sum(rate(node_network_receive_bytes{device!~\"lo\"}[5m]))",
-=======
                   "expr": "sum(cluster_namespace_controller_pod_container:memory_usage:bytes)",
                   "hide": false,
                   "interval": "",
@@ -707,19 +567,6 @@ data:
                   "legendFormat": "Used",
                   "refId": "C",
                   "step": 10,
-                  "textEditor": false
-                },
-                {
-                  "expr": "sum(machine_memory_bytes)",
->>>>>>> Stashed changes
->>>>>>> Add CPU limit percent
-                  "hide": false,
-                  "interval": "",
-                  "intervalFactor": 2,
-                  "legendFormat": "Used",
-                  "refId": "C",
-                  "step": 10,
-                  "target": "alias(transformNull(consolidateBy(sumSeries(snap.$cluster.grafanalabs.kubestate.container.$namespace.$node.*.*.requested.memory.bytes), 'max'), 0), 'Requested')",
                   "textEditor": false
                 },
                 {
@@ -802,29 +649,12 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-<<<<<<< HEAD
-                  "expr": "sum(node_filesystem_size{device!=\"rootfs\",job=\"node-exporter\"}) - sum(node_filesystem_free{device!=\"rootfs\",job=\"node-exporter\"})",
-=======
-<<<<<<< Updated upstream
-                  "expr": "sum(rate(node_network_transmit_bytes{device!~\"lo\"}[5m]))",
-=======
                   "expr": "sum(node_filesystem_size{device!=\"rootfs\",job=\"node-exporter\"}) - sum(node_filesystem_free{device!=\"rootfs\",job=\"node-exporter\"})",
                   "hide": false,
                   "intervalFactor": 2,
                   "legendFormat": "Usage",
                   "refId": "A",
                   "step": 10
-                },
-                {
-                  "expr": "sum(node_filesystem_size{device!=\"rootfs\",job=\"node-exporter\"})",
->>>>>>> Stashed changes
->>>>>>> Add CPU limit percent
-                  "hide": false,
-                  "intervalFactor": 2,
-                  "legendFormat": "Usage",
-                  "refId": "A",
-                  "step": 10,
-                  "target": "alias(sumSeries(groupByNode(snap.$cluster.$node.intel.docker.kube-system.*.snap.stats.filesystem.*.capacity, 10, 'maxSeries')), 'Capacity')"
                 },
                 {
                   "expr": "sum(node_filesystem_size{device!=\"rootfs\",job=\"node-exporter\"})",
@@ -890,37 +720,6 @@ data:
                   "value": "current"
                 }
               ],
-<<<<<<< HEAD
-              "datasource": "$datasource",
-              "editable": true,
-              "error": false,
-              "fontSize": "100%",
-              "id": 30,
-=======
-<<<<<<< Updated upstream
->>>>>>> Add CPU limit percent
-              "links": [],
-              "pageSize": 6,
-              "scroll": true,
-              "showHeader": true,
-              "sort": {
-                "col": null,
-                "desc": false
-              },
-              "span": 3,
-              "styles": [
-                {
-                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                  "pattern": "Time",
-                  "sanitize": false,
-                  "type": "date"
-                },
-                {
-<<<<<<< HEAD
-=======
-                  "name": "range to text",
-                  "value": 2
-=======
               "datasource": "$datasource",
               "editable": true,
               "error": false,
@@ -937,7 +736,6 @@ data:
               "span": 3,
               "styles": [
                 {
->>>>>>> Add CPU limit percent
                   "colorMode": "row",
                   "colors": [
                     "rgba(245, 54, 54, 0.9)",
@@ -952,35 +750,17 @@ data:
                   ],
                   "type": "number",
                   "unit": "short"
-<<<<<<< HEAD
-=======
->>>>>>> Stashed changes
->>>>>>> Add CPU limit percent
                 }
               ],
               "targets": [
                 {
-<<<<<<< HEAD
-=======
-<<<<<<< Updated upstream
-                  "from": "null",
-                  "to": "null",
-                  "text": "N/A"
-=======
->>>>>>> Add CPU limit percent
                   "expr": "sum(kube_deployment_status_replicas_unavailable{job=\"kube-state-metrics\"}) by (deployment) < BOOL sum(kube_deployment_status_replicas_updated{job=\"kube-state-metrics\"}) by (deployment)",
                   "hide": false,
                   "interval": "",
                   "intervalFactor": 2,
                   "legendFormat": "{{ deployment }}",
                   "refId": "B",
-<<<<<<< HEAD
-                  "step": 10,
-                  "target": "aliasByNode(snap.$cluster.grafanalabs.kubestate.deployment.$namespace.*.status.updatedreplicas, 6)"
-=======
                   "step": 10
->>>>>>> Stashed changes
->>>>>>> Add CPU limit percent
                 }
               ],
               "title": "Deployment Replicas - up-to-date",
@@ -1045,22 +825,10 @@ data:
               },
               "targets": [
                 {
-<<<<<<< HEAD
                   "expr": "sum(kube_deployment_status_replicas_available{job=\"kube-state-metrics\"}) + sum(kube_deployment_status_replicas_unavailable{job=\"kube-state-metrics\"})",
                   "intervalFactor": 2,
                   "refId": "A",
-                  "step": 40,
-                  "target": "sumSeries(snap.$cluster.grafanalabs.kubestate.deployment.$namespace.*.spec.desiredreplicas)"
-=======
-                  "refId": "A",
-<<<<<<< Updated upstream
-                  "expr": "sum(rate(container_network_transmit_bytes_total{namespace=\"$deployment_namespace\",pod_name=~\"$deployment_name.*\"}[3m])) + sum(rate(container_network_receive_bytes_total{namespace=\"$deployment_namespace\",pod_name=~\"$deployment_name.*\"}[3m])) ",
-                  "intervalFactor": 2,
-                  "step": 600
-=======
                   "step": 40
->>>>>>> Stashed changes
->>>>>>> Add CPU limit percent
                 }
               ],
               "thresholds": "",
@@ -1133,22 +901,10 @@ data:
               },
               "targets": [
                 {
-<<<<<<< HEAD
                   "expr": "sum(kube_deployment_status_replicas_updated{job=\"kube-state-metrics\"})",
                   "intervalFactor": 2,
                   "refId": "A",
-                  "step": 40,
-                  "target": "sumSeries(snap.$cluster.grafanalabs.kubestate.deployment.$namespace.*.status.updatedreplicas)"
-=======
-                  "refId": "A",
-<<<<<<< Updated upstream
-                  "expr": "kube_deployment_status_replicas_available{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
-                  "intervalFactor": 2,
-                  "step": 600
-=======
                   "step": 40
->>>>>>> Stashed changes
->>>>>>> Add CPU limit percent
                 }
               ],
               "thresholds": "",
@@ -1224,16 +980,7 @@ data:
                   "expr": "sum(kube_deployment_status_replicas_unavailable{job=\"kube-state-metrics\"})",
                   "intervalFactor": 2,
                   "refId": "A",
-<<<<<<< HEAD
-                  "step": 40,
-                  "target": "sumSeries(snap.$cluster.grafanalabs.kubestate.deployment.$namespace.*.status.unavailablereplicas)"
-=======
-<<<<<<< Updated upstream
-                  "step": 600
-=======
                   "step": 40
->>>>>>> Stashed changes
->>>>>>> Add CPU limit percent
                 }
               ],
               "thresholds": "",
@@ -1322,18 +1069,8 @@ data:
                   "expr": "sum(kube_node_status_ready{job=\"kube-state-metrics\",condition=\"true\"}) - sum(kube_pod_status_ready{job=\"kube-state-metrics\",pod=~\"kube-apiserver-.*\"})",
                   "intervalFactor": 2,
                   "refId": "A",
-<<<<<<< HEAD
-                  "step": 40,
-                  "target": "countSeries(snap.$cluster.grafanalabs.kubestate.node.$node.status.outofdisk)",
-                  "textEditor": false
-=======
-<<<<<<< Updated upstream
-                  "step": 600
-=======
                   "step": 40,
                   "textEditor": false
->>>>>>> Stashed changes
->>>>>>> Add CPU limit percent
                 }
               ],
               "thresholds": "",
@@ -1369,7 +1106,6 @@ data:
                 "thresholdLabels": false,
                 "thresholdMarkers": true
               },
-<<<<<<< HEAD
               "id": 8,
               "interval": null,
               "links": [],
@@ -1411,7 +1147,6 @@ data:
                   "intervalFactor": 2,
                   "refId": "A",
                   "step": 40,
-                  "target": "consolidateBy(sumSeries(snap.$cluster.grafanalabs.kubestate.node.$node.status.outofdisk), 'max')",
                   "textEditor": false
                 }
               ],
@@ -1489,7 +1224,6 @@ data:
                   "intervalFactor": 2,
                   "refId": "A",
                   "step": 40,
-                  "target": "consolidateBy(sumSeries(snap.$cluster.grafanalabs.kubestate.node.$node.spec.unschedulable), 'max')",
                   "textEditor": false
                 }
               ],
@@ -1580,7 +1314,6 @@ data:
                   "intervalFactor": 2,
                   "refId": "A",
                   "step": 40,
-                  "target": "consolidateBy(sumSeries(snap.$cluster.grafanalabs.kubestate.pod.$namespace.$node.*.status.phase.Running), 'max')",
                   "textEditor": false
                 }
               ],
@@ -1659,7 +1392,6 @@ data:
                   "intervalFactor": 2,
                   "refId": "A",
                   "step": 40,
-                  "target": "transformNull(consolidateBy(sumSeries(snap.$cluster.grafanalabs.kubestate.pod.$namespace.$node.*.status.phase.Pending), 'max'), 0)",
                   "textEditor": false
                 }
               ],
@@ -1738,7 +1470,6 @@ data:
                   "intervalFactor": 2,
                   "refId": "A",
                   "step": 40,
-                  "target": "transformNull(consolidateBy(sumSeries(snap.$cluster.grafanalabs.kubestate.pod.$namespace.$node.*.status.phase.Failed), 'max'), 0)",
                   "textEditor": false
                 }
               ],
@@ -1817,7 +1548,6 @@ data:
                   "intervalFactor": 2,
                   "refId": "A",
                   "step": 40,
-                  "target": "transformNull(consolidateBy(sumSeries(snap.$cluster.grafanalabs.kubestate.pod.$namespace.$node.*.status.phase.Succeeded), 'max'), 0)",
                   "textEditor": false
                 }
               ],
@@ -1896,7 +1626,6 @@ data:
                   "intervalFactor": 2,
                   "refId": "A",
                   "step": 40,
-                  "target": "transformNull(consolidateBy(sumSeries(snap.$cluster.grafanalabs.kubestate.pod.$namespace.$node.*.status.phase.Unknown), 'max'), 0)",
                   "textEditor": false
                 }
               ],
@@ -1987,7 +1716,6 @@ data:
                   "intervalFactor": 2,
                   "refId": "A",
                   "step": 40,
-                  "target": "consolidateBy(sumSeries(snap.$cluster.grafanalabs.kubestate.container.$namespace.$node.*.*.status.running), 'max')",
                   "textEditor": false
                 }
               ],
@@ -2064,8 +1792,7 @@ data:
                   "expr": "sum(kube_pod_container_status_waiting{job=\"kube-state-metrics\"})",
                   "intervalFactor": 2,
                   "refId": "A",
-                  "step": 40,
-                  "target": "consolidateBy(sumSeries(snap.$cluster.grafanalabs.kubestate.container.$namespace.$node.*.*.status.waiting), 'max')"
+                  "step": 40
                 }
               ],
               "thresholds": "",
@@ -2104,23 +1831,6 @@ data:
               },
               "id": 23,
               "interval": null,
-=======
-<<<<<<< Updated upstream
-              "id": 1,
-              "isNew": true,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": true,
-                "total": false,
-                "values": false,
-                "hideZero": false
-=======
-              "id": 8,
-              "interval": null,
->>>>>>> Add CPU limit percent
               "links": [],
               "mappingType": 1,
               "mappingTypes": [
@@ -2147,16 +1857,11 @@ data:
                   "to": "null"
                 }
               ],
-<<<<<<< HEAD
               "span": 3,
-=======
-              "span": 4,
->>>>>>> Add CPU limit percent
               "sparkline": {
                 "fillColor": "rgba(31, 118, 189, 0.18)",
                 "full": false,
                 "lineColor": "rgb(31, 120, 193)",
-<<<<<<< HEAD
                 "show": true
               },
               "targets": [
@@ -2164,8 +1869,7 @@ data:
                   "expr": "sum(kube_pod_container_status_terminated{job=\"kube-state-metrics\"})",
                   "intervalFactor": 2,
                   "refId": "A",
-                  "step": 40,
-                  "target": "consolidateBy(sumSeries(snap.$cluster.grafanalabs.kubestate.container.$namespace.$node.*.*.status.terminated), 'max')"
+                  "step": 40
                 }
               ],
               "thresholds": "",
@@ -2244,8 +1948,7 @@ data:
                   "intervalFactor": 2,
                   "legendFormat": "",
                   "refId": "A",
-                  "step": 40,
-                  "target": "derivative(sumSeries(snap.$cluster.grafanalabs.kubestate.container.$namespace.$node.*.*.status.restarts))"
+                  "step": 40
                 }
               ],
               "thresholds": "",
@@ -2255,25 +1958,6 @@ data:
               "valueFontSize": "80%",
               "valueMaps": [
                 {
-=======
-                "show": false
-              },
-              "targets": [
-                {
-                  "expr": "sum(kube_node_status_out_of_disk{condition=\"true\", job=\"kube-state-metrics\"})",
-                  "intervalFactor": 2,
-                  "refId": "A",
-                  "step": 40,
-                  "textEditor": false
-                }
-              ],
-              "thresholds": "1,1",
-              "title": "Nodes Out of Disk",
-              "type": "singlestat",
-              "valueFontSize": "100%",
-              "valueMaps": [
-                {
->>>>>>> Add CPU limit percent
                   "op": "=",
                   "text": "N/A",
                   "value": "null"
@@ -2283,7 +1967,6 @@ data:
             },
             {
               "cacheTimeout": null,
-<<<<<<< HEAD
               "colorBackground": false,
               "colorValue": false,
               "colors": [
@@ -2293,16 +1976,6 @@ data:
               ],
               "datasource": "$datasource",
               "decimals": null,
-=======
-              "colorBackground": true,
-              "colorValue": false,
-              "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(245, 54, 54, 0.9)"
-              ],
-              "datasource": "$datasource",
->>>>>>> Add CPU limit percent
               "editable": true,
               "error": false,
               "format": "none",
@@ -2313,16 +1986,11 @@ data:
                 "thresholdLabels": false,
                 "thresholdMarkers": true
               },
-<<<<<<< HEAD
               "id": 19,
-=======
-              "id": 13,
->>>>>>> Add CPU limit percent
               "interval": null,
               "links": [],
               "mappingType": 1,
               "mappingTypes": [
-<<<<<<< HEAD
                 {
                   "name": "value to text",
                   "value": 1
@@ -2359,7 +2027,6 @@ data:
                   "intervalFactor": 2,
                   "refId": "A",
                   "step": 40,
-                  "target": "consolidateBy(sumSeries(snap.$cluster.grafanalabs.kubestate.container.$namespace.$node.*.*.requested.cpu.cores), 'max')",
                   "textEditor": false
                 }
               ],
@@ -2403,9 +2070,6 @@ data:
               "mappingType": 1,
               "mappingTypes": [
                 {
-=======
-                {
->>>>>>> Add CPU limit percent
                   "name": "value to text",
                   "value": 1
                 },
@@ -2428,16 +2092,11 @@ data:
                   "to": "null"
                 }
               ],
-<<<<<<< HEAD
               "span": 6,
-=======
-              "span": 4,
->>>>>>> Add CPU limit percent
               "sparkline": {
                 "fillColor": "rgba(31, 118, 189, 0.18)",
                 "full": false,
                 "lineColor": "rgb(31, 120, 193)",
-<<<<<<< HEAD
                 "show": true
               },
               "targets": [
@@ -2446,7 +2105,6 @@ data:
                   "intervalFactor": 2,
                   "refId": "A",
                   "step": 40,
-                  "target": "consolidateBy(sumSeries(snap.$cluster.grafanalabs.kubestate.container.$namespace.$node.*.*.requested.memory.bytes), 'max')",
                   "textEditor": false
                 }
               ],
@@ -2454,23 +2112,6 @@ data:
               "title": "Memory Requested By Containers",
               "type": "singlestat",
               "valueFontSize": "80%",
-=======
-                "show": false
-              },
-              "targets": [
-                {
-                  "expr": "sum(kube_node_spec_unschedulable) - sum(kube_pod_status_ready{job=\"kube-state-metrics\",pod=~\"kube-apiserver-.*\"})",
-                  "intervalFactor": 2,
-                  "refId": "A",
-                  "step": 40,
-                  "textEditor": false
-                }
-              ],
-              "thresholds": "1",
-              "title": "Unschedulable Nodes",
-              "type": "singlestat",
-              "valueFontSize": "100%",
->>>>>>> Add CPU limit percent
               "valueMaps": [
                 {
                   "op": "=",
@@ -2485,7 +2126,6 @@ data:
           "repeatIteration": null,
           "repeatRowId": null,
           "showTitle": true,
-<<<<<<< HEAD
           "title": "Containers",
           "titleSize": "h3"
         }
@@ -2515,874 +2155,6 @@ data:
       },
       "time": {
         "from": "now-30m",
-=======
-          "title": "Nodes",
-          "titleSize": "h3"
-        },
-        {
-          "collapse": false,
-          "height": "120",
-          "panels": [
-            {
-              "cacheTimeout": null,
-              "colorBackground": false,
-              "colorValue": false,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(187, 194, 208, 0.97)"
-              ],
-              "datasource": "$datasource",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "format": "none",
-              "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-              },
-              "id": 9,
-              "interval": null,
-              "links": [],
-              "mappingType": 1,
-              "mappingTypes": [
-                {
-                  "name": "value to text",
-                  "value": 1
-                },
-                {
-                  "name": "range to text",
-                  "value": 2
-                }
-              ],
-              "maxDataPoints": 100,
-              "nullPointMode": "connected",
-              "nullText": null,
-              "postfix": "",
-              "postfixFontSize": "50%",
-              "prefix": "",
-              "prefixFontSize": "50%",
-              "rangeMaps": [
-                {
-                  "from": "null",
-                  "text": "N/A",
-                  "to": "null"
-                }
-              ],
-              "span": 6,
-              "sparkline": {
-                "fillColor": "rgba(31, 189, 41, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 200, 32)",
-                "show": true
-              },
-              "targets": [
-                {
-                  "expr": "sum(kube_pod_status_ready{job=\"kube-state-metrics\"})",
-                  "intervalFactor": 2,
-                  "refId": "A",
-                  "step": 40,
-                  "textEditor": false
-                }
-              ],
-              "thresholds": "",
-              "title": "Pods Running",
-              "type": "singlestat",
-              "valueFontSize": "80%",
-              "valueMaps": [
-                {
-                  "op": "=",
-                  "text": "N/A",
-                  "value": "null"
-                }
-              ],
-              "valueName": "current"
-            },
-            {
-              "cacheTimeout": null,
-              "colorBackground": false,
-              "colorValue": false,
-              "colors": [
-                "rgba(187, 194, 208, 0.97)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(245, 54, 54, 0.9)"
-              ],
-              "datasource": "$datasource",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "format": "none",
-              "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-              },
-              "id": 31,
-              "interval": null,
-              "links": [],
-              "mappingType": 1,
-              "mappingTypes": [
-                {
-                  "name": "value to text",
-                  "value": 1
-                },
-                {
-                  "name": "range to text",
-                  "value": 2
-                }
-              ],
-              "maxDataPoints": 100,
-              "nullPointMode": "connected",
-              "nullText": null,
-              "postfix": "",
-              "postfixFontSize": "50%",
-              "prefix": "",
-              "prefixFontSize": "50%",
-              "rangeMaps": [
-                {
-                  "from": "null",
-                  "text": "N/A",
-                  "to": "null"
-                }
-              ],
-              "span": 6,
-              "sparkline": {
-                "fillColor": "rgba(31, 189, 41, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 200, 32)",
-                "show": true
-              },
-              "targets": [
-                {
-                  "expr": "sum(kube_pod_status_scheduled{condition=\"true\",job=\"kube-state-metrics\"}) - sum(kube_pod_status_ready{job=\"kube-state-metrics\"})",
-                  "intervalFactor": 2,
-                  "refId": "A",
-                  "step": 40,
-                  "textEditor": false
-                }
-              ],
-              "thresholds": "0,5,20",
-              "title": "Pods Pending",
-              "type": "singlestat",
-              "valueFontSize": "80%",
-              "valueMaps": [
-                {
-                  "op": "=",
-                  "text": "N/A",
-                  "value": "null"
-                }
-              ],
-              "valueName": "current"
-            },
-            {
-              "cacheTimeout": null,
-              "colorBackground": false,
-              "colorValue": true,
-              "colors": [
-                "rgba(187, 194, 208, 0.97)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(245, 54, 54, 0.9)"
-              ],
-              "datasource": "$datasource",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "format": "none",
-              "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-              },
-              "id": 33,
-              "interval": null,
-              "links": [],
-              "mappingType": 1,
-              "mappingTypes": [
-                {
-                  "name": "value to text",
-                  "value": 1
-                },
-                {
-                  "name": "range to text",
-                  "value": 2
-                }
-              ],
-              "maxDataPoints": 100,
-              "nullPointMode": "connected",
-              "nullText": null,
-              "postfix": "",
-              "postfixFontSize": "50%",
-              "prefix": "",
-              "prefixFontSize": "50%",
-              "rangeMaps": [
-                {
-                  "from": "null",
-                  "text": "N/A",
-                  "to": "null"
-                }
-              ],
-              "span": 4,
-              "sparkline": {
-                "fillColor": "rgba(31, 189, 41, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 200, 32)",
-                "show": true
-              },
-              "targets": [
-                {
-                  "expr": "sum(kube_pod_status_phase{job=\"kube-state-metrics\",phase=\"Failed\"})",
-                  "intervalFactor": 2,
-                  "refId": "A",
-                  "step": 40,
-                  "textEditor": false
-                }
-              ],
-              "thresholds": "0,5,20",
-              "title": "Pods Failed",
-              "type": "singlestat",
-              "valueFontSize": "80%",
-              "valueMaps": [
-                {
-                  "op": "=",
-                  "text": "0",
-                  "value": "null"
-                }
-              ],
-              "valueName": "current"
-            },
-            {
-              "cacheTimeout": null,
-              "colorBackground": false,
-              "colorValue": false,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(187, 194, 208, 0.97)"
-              ],
-              "datasource": "$datasource",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "format": "none",
-              "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-              },
-              "id": 34,
-              "interval": null,
-              "links": [],
-              "mappingType": 1,
-              "mappingTypes": [
-                {
-                  "name": "value to text",
-                  "value": 1
-                },
-                {
-                  "name": "range to text",
-                  "value": 2
-                }
-              ],
-              "maxDataPoints": 100,
-              "nullPointMode": "connected",
-              "nullText": null,
-              "postfix": "",
-              "postfixFontSize": "50%",
-              "prefix": "",
-              "prefixFontSize": "50%",
-              "rangeMaps": [
-                {
-                  "from": "null",
-                  "text": "N/A",
-                  "to": "null"
-                }
-              ],
-              "span": 4,
-              "sparkline": {
-                "fillColor": "rgba(31, 189, 41, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 200, 32)",
-                "show": true
-              },
-              "targets": [
-                {
-                  "expr": "sum(kube_pod_status_phase{job=\"kube-state-metrics\",phase=\"Succeeded\"})",
-                  "intervalFactor": 2,
-                  "refId": "A",
-                  "step": 40,
-                  "textEditor": false
-                }
-              ],
-              "thresholds": "",
-              "title": "Pods Succeeded",
-              "type": "singlestat",
-              "valueFontSize": "80%",
-              "valueMaps": [
-                {
-                  "op": "=",
-                  "text": "0",
-                  "value": "null"
-                }
-              ],
-              "valueName": "current"
-            },
-            {
-              "cacheTimeout": null,
-              "colorBackground": false,
-              "colorValue": false,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(187, 194, 208, 0.97)"
-              ],
-              "datasource": "$datasource",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "format": "none",
-              "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-              },
-              "id": 35,
-              "interval": null,
-              "links": [],
-              "mappingType": 1,
-              "mappingTypes": [
-                {
-                  "name": "value to text",
-                  "value": 1
-                },
-                {
-                  "name": "range to text",
-                  "value": 2
-                }
-              ],
-              "maxDataPoints": 100,
-              "nullPointMode": "connected",
-              "nullText": null,
-              "postfix": "",
-              "postfixFontSize": "50%",
-              "prefix": "",
-              "prefixFontSize": "50%",
-              "rangeMaps": [
-                {
-                  "from": "null",
-                  "text": "N/A",
-                  "to": "null"
-                }
-              ],
-              "span": 4,
-              "sparkline": {
-                "fillColor": "rgba(31, 189, 41, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 200, 32)",
-                "show": true
-              },
-              "targets": [
-                {
-                  "expr": "sum(kube_pod_status_phase{job=\"kube-state-metrics\",phase=\"Unknown\"})",
-                  "intervalFactor": 2,
-                  "refId": "A",
-                  "step": 40,
-                  "textEditor": false
-                }
-              ],
-              "thresholds": "",
-              "title": "Pods - Status Unknown",
-              "type": "singlestat",
-              "valueFontSize": "80%",
-              "valueMaps": [
-                {
-                  "op": "=",
-                  "text": "0",
-                  "value": "null"
-                }
-              ],
-              "valueName": "current"
-            }
-          ],
-          "repeat": null,
-          "repeatIteration": null,
-          "repeatRowId": null,
-          "showTitle": true,
-          "title": "Pods",
-          "titleSize": "h3"
-        },
-        {
-          "collapse": false,
-          "height": "125",
-          "panels": [
-            {
-              "cacheTimeout": null,
-              "colorBackground": false,
-              "colorValue": false,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "datasource": "$datasource",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "format": "none",
-              "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-              },
-              "id": 12,
-              "interval": null,
-              "links": [],
-              "mappingType": 1,
-              "mappingTypes": [
-                {
-                  "name": "value to text",
-                  "value": 1
-                },
-                {
-                  "name": "range to text",
-                  "value": 2
-                }
-              ],
-              "maxDataPoints": 100,
-              "nullPointMode": "connected",
-              "nullText": null,
-              "postfix": "",
-              "postfixFontSize": "50%",
-              "prefix": "",
-              "prefixFontSize": "50%",
-              "rangeMaps": [
-                {
-                  "from": "null",
-                  "text": "N/A",
-                  "to": "null"
-                }
-              ],
-              "span": 3,
-              "sparkline": {
-                "fillColor": "rgba(89, 77, 192, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": true
-              },
-              "targets": [
-                {
-                  "expr": "sum(kube_pod_container_status_running{job=\"kube-state-metrics\"})",
-                  "intervalFactor": 2,
-                  "refId": "A",
-                  "step": 40,
-                  "textEditor": false
-                }
-              ],
-              "thresholds": "",
-              "title": "Containers Running",
-              "type": "singlestat",
-              "valueFontSize": "80%",
-              "valueMaps": [
-                {
-                  "op": "=",
-                  "text": "N/A",
-                  "value": "null"
-                }
-              ],
-              "valueName": "current"
-            },
-            {
-              "cacheTimeout": null,
-              "colorBackground": false,
-              "colorValue": false,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "datasource": "$datasource",
-              "editable": true,
-              "error": false,
-              "format": "none",
-              "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-              },
-              "id": 11,
-              "interval": null,
-              "links": [],
-              "mappingType": 1,
-              "mappingTypes": [
-                {
-                  "name": "value to text",
-                  "value": 1
-                },
-                {
-                  "name": "range to text",
-                  "value": 2
-                }
-              ],
-              "maxDataPoints": 100,
-              "nullPointMode": "connected",
-              "nullText": null,
-              "postfix": "",
-              "postfixFontSize": "50%",
-              "prefix": "",
-              "prefixFontSize": "50%",
-              "rangeMaps": [
-                {
-                  "from": "null",
-                  "text": "N/A",
-                  "to": "null"
-                }
-              ],
-              "span": 3,
-              "sparkline": {
-                "fillColor": "rgba(31, 41, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": true
-              },
-              "targets": [
-                {
-                  "expr": "sum(kube_pod_container_status_waiting{job=\"kube-state-metrics\"})",
-                  "intervalFactor": 2,
-                  "refId": "A",
-                  "step": 40
-                }
-              ],
-              "thresholds": "",
-              "title": "Containers Waiting",
-              "type": "singlestat",
-              "valueFontSize": "80%",
-              "valueMaps": [
-                {
-                  "op": "=",
-                  "text": "N/A",
-                  "value": "null"
-                }
-              ],
-              "valueName": "current"
-            },
-            {
-              "cacheTimeout": null,
-              "colorBackground": false,
-              "colorValue": false,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "datasource": "$datasource",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "format": "none",
-              "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-              },
-              "id": 23,
-              "interval": null,
-              "links": [],
-              "mappingType": 1,
-              "mappingTypes": [
-                {
-                  "name": "value to text",
-                  "value": 1
-                },
-                {
-                  "name": "range to text",
-                  "value": 2
-                }
-              ],
-              "maxDataPoints": 100,
-              "nullPointMode": "connected",
-              "nullText": null,
-              "postfix": "",
-              "postfixFontSize": "50%",
-              "prefix": "",
-              "prefixFontSize": "50%",
-              "rangeMaps": [
-                {
-                  "from": "null",
-                  "text": "N/A",
-                  "to": "null"
-                }
-              ],
-              "span": 3,
-              "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": true
-              },
-              "targets": [
-                {
-                  "expr": "sum(kube_pod_container_status_terminated{job=\"kube-state-metrics\"})",
-                  "intervalFactor": 2,
-                  "refId": "A",
-                  "step": 40
-                }
-              ],
-              "thresholds": "",
-              "title": "Containers Terminated",
-              "type": "singlestat",
-              "valueFontSize": "80%",
-              "valueMaps": [
-                {
-                  "op": "=",
-                  "text": "N/A",
-                  "value": "null"
-                }
-              ],
-              "valueName": "current"
-            },
-            {
-              "cacheTimeout": null,
-              "colorBackground": false,
-              "colorValue": false,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "datasource": "$datasource",
-              "decimals": 0,
-              "editable": true,
-              "error": false,
-              "format": "none",
-              "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
->>>>>>> Stashed changes
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 12,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "kube_deployment_status_replicas{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
-                  "intervalFactor": 2,
-                  "legendFormat": "current replicas",
-                  "refId": "A",
-<<<<<<< Updated upstream
-                  "step": 30
-=======
-                  "step": 40
-                }
-              ],
-              "thresholds": "",
-              "timeFrom": null,
-              "title": "Container Restarts",
-              "type": "singlestat",
-              "valueFontSize": "80%",
-              "valueMaps": [
-                {
-                  "op": "=",
-                  "text": "N/A",
-                  "value": "null"
-                }
-              ],
-              "valueName": "current"
-            },
-            {
-              "cacheTimeout": null,
-              "colorBackground": false,
-              "colorValue": false,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "datasource": "$datasource",
-              "decimals": null,
-              "editable": true,
-              "error": false,
-              "format": "none",
-              "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-              },
-              "id": 19,
-              "interval": null,
-              "links": [],
-              "mappingType": 1,
-              "mappingTypes": [
-                {
-                  "name": "value to text",
-                  "value": 1
->>>>>>> Stashed changes
-                },
-                {
-                  "expr": "kube_deployment_status_replicas_available{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
-                  "intervalFactor": 2,
-<<<<<<< Updated upstream
-                  "legendFormat": "available",
-                  "refId": "B",
-                  "step": 30
-                },
-=======
-                  "refId": "A",
-                  "step": 40,
-                  "textEditor": false
-                }
-              ],
-              "thresholds": "",
-              "title": "CPU Cores Requested by Containers",
-              "type": "singlestat",
-              "valueFontSize": "80%",
-              "valueMaps": [
-                {
-                  "op": "=",
-                  "text": "N/A",
-                  "value": "null"
-                }
-              ],
-              "valueName": "current"
-            },
-            {
-              "cacheTimeout": null,
-              "colorBackground": false,
-              "colorValue": false,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "datasource": "$datasource",
-              "decimals": null,
-              "editable": true,
-              "error": false,
-              "format": "decbytes",
-              "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-              },
-              "id": 20,
-              "interval": null,
-              "links": [],
-              "mappingType": 1,
-              "mappingTypes": [
->>>>>>> Stashed changes
-                {
-                  "expr": "kube_deployment_status_replicas_unavailable{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
-                  "intervalFactor": 2,
-                  "legendFormat": "unavailable",
-                  "refId": "C",
-                  "step": 30
-                },
-                {
-                  "expr": "kube_deployment_status_replicas_updated{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
-                  "intervalFactor": 2,
-                  "legendFormat": "updated",
-                  "refId": "D",
-                  "step": 30
-                },
-                {
-                  "expr": "kube_deployment_spec_replicas{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}",
-                  "intervalFactor": 2,
-                  "legendFormat": "desired",
-                  "refId": "E",
-                  "step": 30
-                }
-              ],
-              "thresholds": [],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Replicas",
-              "tooltip": {
-                "msResolution": true,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "type": "graph",
-              "xaxis": {
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-              },
-              "yaxes": [
-                {
-<<<<<<< Updated upstream
-                  "format": "none",
-                  "label": "",
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                },
-=======
-                  "expr": "sum(kube_pod_container_resource_requests_memory_bytes)",
-                  "intervalFactor": 2,
-                  "refId": "A",
-                  "step": 40,
-                  "textEditor": false
-                }
-              ],
-              "thresholds": "",
-              "title": "Memory Requested By Containers",
-              "type": "singlestat",
-              "valueFontSize": "80%",
-              "valueMaps": [
->>>>>>> Stashed changes
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": false
-                }
-              ],
-              "transparent": false
-            }
-          ],
-          "title": "New row",
-          "showTitle": false
-        }
-      ],
-      "time": {
-        "from": "now-6h",
->>>>>>> Add CPU limit percent
         "to": "now"
       },
       "timepicker": {
@@ -3410,59 +2182,9 @@ data:
           "30d"
         ]
       },
-<<<<<<< HEAD
-      "timezone": "browser",
-      "title": "Kubernetes Cluster",
-      "version": 84
-=======
-<<<<<<< Updated upstream
-      "templating": {
-        "list": [
-          {
-            "allValue": ".*",
-            "current": {},
-            "datasource": "${DS_PROMETHEUS}",
-            "hide": 0,
-            "includeAll": false,
-            "label": "Namespace",
-            "multi": false,
-            "name": "deployment_namespace",
-            "options": [],
-            "query": "label_values(kube_deployment_metadata_generation, namespace)",
-            "refresh": 1,
-            "regex": "",
-            "sort": 0,
-            "tagValuesQuery": null,
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-          },
-          {
-            "allValue": null,
-            "current": {},
-            "datasource": "${DS_PROMETHEUS}",
-            "hide": 0,
-            "includeAll": false,
-            "label": "Deployment",
-            "multi": false,
-            "name": "deployment_name",
-            "options": [],
-            "query": "label_values(kube_deployment_metadata_generation{namespace=\"$deployment_namespace\"}, deployment)",
-            "refresh": 1,
-            "regex": "",
-            "sort": 0,
-            "tagValuesQuery": "",
-            "tagsQuery": "deployment",
-            "type": "query",
-            "useTags": false
-          }
-        ]
-      },
-=======
       "timezone": "browser",
       "title": "Kubernetes Cluster",
       "version": 6
->>>>>>> Add CPU limit percent
     }
     ,
       "inputs": [
@@ -3479,10 +2201,6 @@ data:
     {
       "dashboard":
     {
-<<<<<<< HEAD
-=======
->>>>>>> Stashed changes
->>>>>>> Add CPU limit percent
       "annotations": {
         "list": []
       },
@@ -4036,674 +2754,765 @@ data:
     }
   kubernetes-pod-dashboard.json: |
     {
-      "dashboard":
-    {
-      "annotations": {
-        "list": []
-      },
-      "description": "Summary metrics about Pods running on Kubernetes nodes.",
-      "editable": true,
-      "gnetId": 482,
-      "graphTooltip": 1,
-      "hideControls": false,
-      "id": null,
-      "links": [
-        {
-          "asDropdown": true,
-          "icon": "external link",
-          "includeVars": true,
-          "tags": [
-            "kubernetes-app"
-          ],
-          "title": "Dashboards",
-          "type": "dashboards"
-        }
-      ],
-      "refresh": "10s",
-      "rows": [
-        {
-          "collapse": false,
-          "height": 355,
-          "panels": [
-            {
-              "alerting": {},
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "$datasource",
-              "editable": true,
-              "error": false,
-              "fill": 1,
-              "grid": {},
-              "id": 6,
-              "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": true,
-                "hideZero": false,
-                "max": true,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "sort": "current",
-                "sortDesc": true,
-                "total": false,
-                "values": true
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "minSpan": 6,
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 6,
-              "stack": true,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum by (container_name)(rate(cluster_namespace_controller_pod_container:cpu_usage:rate{container_name!=\"POD\",pod_name=~\"$pod\"}[$interval] ) )",
-                  "intervalFactor": 2,
-                  "legendFormat": "{{ container_name }}",
-                  "refId": "A",
-                  "step": 4,
-                  "target": "groupByNode(exclude(perSecond(snap.$cluster.$node.intel.docker.$namespace.$pod.$container.stats.cgroups.cpu_stats.cpu_usage.total_usage), 'POD'), 7, 'sum')",
-                  "textEditor": false
-                }
-              ],
-              "thresholds": [],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "CPU Usage (per container)",
-              "tooltip": {
-                "msResolution": false,
-                "shared": false,
-                "sort": 0,
-                "value_type": "individual"
-              },
-              "transparent": false,
-              "type": "graph",
-              "xaxis": {
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-              },
-              "yaxes": [
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "alerting": {},
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "$datasource",
-              "editable": true,
-              "error": false,
-              "fill": 1,
-              "grid": {},
-              "id": 1,
-              "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "max": true,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "sortDesc": true,
-                "total": false,
-                "values": true
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "minSpan": 6,
-              "nullPointMode": "connected",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 6,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum by(container_name) (cluster_namespace_controller_pod_container:memory_usage:bytes{container_name!=\"POD\",pod_name=~\"$pod\"})",
-                  "hide": false,
-                  "intervalFactor": 1,
-                  "legendFormat": " {{ container_name }}",
-                  "refId": "A",
-                  "step": 2,
-                  "target": "groupByNode(exclude(averageAbove(snap.$cluster.$node.intel.docker.$namespace.$pod.$container.stats.cgroups.memory_stats.usage.usage, 0), 'POD'), 7, 'sum')",
-                  "textEditor": false
-                }
-              ],
-              "thresholds": [],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Total Memory Usage (per container)",
-              "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-              },
-              "yaxes": [
-                {
-                  "format": "decbytes",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ]
-            },
-            {
-              "alerting": {},
-              "aliasColors": {},
-              "bars": false,
-              "datasource": "$datasource",
-              "editable": true,
-              "error": false,
-              "fill": 1,
-              "grid": {},
-              "id": 2,
-              "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sortDesc": true,
-                "total": false,
-                "values": true
-              },
-              "lines": true,
-              "linewidth": 2,
-              "links": [],
-              "minSpan": 6,
-              "nullPointMode": "null as zero",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "span": 12,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum by(pod_name) (rate(container_network_receive_bytes_total{pod_name=~\"$pod.*\"}[$interval]))",
-                  "intervalFactor": 2,
-                  "legendFormat": "{{ pod_name }} Received",
-                  "refId": "A",
-                  "step": 2,
-                  "target": "groupByNode(exclude(perSecond(snap.$cluster.$node.intel.docker.$namespace.$pod.$container.stats.network.*.rx_bytes), 'POD'), 7, 'sum')",
-                  "textEditor": false
-                },
-                {
-                  "expr": "-sum by(pod_name)  (rate(container_network_transmit_bytes_total{pod_name=~\"$pod.*\"}[$interval]))",
-                  "intervalFactor": 2,
-                  "legendFormat": "{{ pod_name }} Sent",
-                  "refId": "B",
-                  "step": 2
-                }
-              ],
-              "thresholds": [],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Network Traffic (per pod)",
-              "tooltip": {
-                "msResolution": false,
-                "shared": false,
-                "sort": 0,
-                "value_type": "cumulative"
-              },
-              "transparent": false,
-              "type": "graph",
-              "xaxis": {
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-              },
-              "yaxes": [
-                {
-                  "format": "decbytes",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": false
-                }
-              ]
-            }
-          ],
-          "repeat": null,
-          "repeatIteration": null,
-          "repeatRowId": null,
-          "showTitle": true,
-          "title": "General",
-          "titleSize": "h6"
-        },
-        {
-          "collapse": false,
-          "height": 439,
-          "panels": [
-            {
-              "columns": [
-                {
-                  "text": "Current",
-                  "value": "current"
-                }
-              ],
-              "datasource": "prometheus",
-              "fontSize": "100%",
-              "id": 7,
-              "links": [],
-              "minSpan": 4,
-              "pageSize": null,
-              "scroll": true,
-              "showHeader": true,
-              "sort": {
-                "col": 0,
-                "desc": true
-              },
-              "span": 4,
-              "styles": [
-                {
-                  "colorMode": null,
-                  "colors": [
-                    "rgba(245, 54, 54, 0.9)",
-                    "rgba(237, 129, 40, 0.89)",
-                    "rgba(50, 172, 45, 0.97)"
-                  ],
-                  "decimals": 2,
-                  "pattern": "/.*/",
-                  "thresholds": [
-                    "10000000",
-                    " 25000000"
-                  ],
-                  "type": "number",
-                  "unit": "decbytes"
-                }
-              ],
-              "targets": [
-                {
-                  "expr": "cluster_namespace_controller_pod_container:memory_usage:bytes{container_name!=\"POD\",pod_name=~\"$pod\"}",
-                  "intervalFactor": 2,
-                  "legendFormat": "{{ container_name }}",
-                  "refId": "A",
-                  "step": 4
-                }
-              ],
-              "title": "Memory Usage",
-              "transform": "timeseries_aggregations",
-              "type": "table"
-            },
-            {
-              "columns": [
-                {
-                  "text": "Current",
-                  "value": "current"
-                }
-              ],
-              "datasource": "$datasource",
-              "fontSize": "100%",
-              "id": 8,
-              "links": [],
-              "minSpan": 4,
-              "pageSize": null,
-              "scroll": true,
-              "showHeader": true,
-              "sort": {
-                "col": 1,
-                "desc": true
-              },
-              "span": 4,
-              "styles": [
-                {
-                  "colorMode": "cell",
-                  "colors": [
-                    "rgba(50, 172, 45, 0.97)",
-                    "rgba(237, 129, 40, 0.89)",
-                    "rgba(245, 54, 54, 0.9)"
-                  ],
-                  "decimals": 2,
-                  "pattern": "/.*/",
-                  "thresholds": [
-                    "80",
-                    "90"
-                  ],
-                  "type": "number",
-                  "unit": "percent"
-                }
-              ],
-              "targets": [
-                {
-                  "expr": "sum(100 - ((cluster_namespace_controller_pod_container:spec_memory_limit_bytes{container_name!=\"POD\",pod_name=~\"$pod\"} - cluster_namespace_controller_pod_container:memory_usage:bytes{container_name!=\"POD\",pod_name=~\"$pod\"})  * 100 / cluster_namespace_controller_pod_container:spec_memory_limit_bytes{container_name!=\"POD\",pod_name=~\"$pod\"}) ) by (pod_name) ",
-                  "hide": false,
-                  "intervalFactor": 2,
-                  "legendFormat": "{{pod_name}}",
-                  "refId": "A",
-                  "step": 4
-                }
-              ],
-              "title": "Memory usage (in percent of limit)",
-              "transform": "timeseries_aggregations",
-              "type": "table"
-            },
-            {
-              "columns": [
-                {
-                  "text": "Current",
-                  "value": "current"
-                }
-              ],
-              "datasource": "$datasource",
-              "fontSize": "100%",
-              "id": 9,
-              "links": [],
-              "minSpan": 4,
-              "pageSize": null,
-              "scroll": true,
-              "showHeader": true,
-              "sort": {
-                "col": 0,
-                "desc": true
-              },
-              "span": 4,
-              "styles": [
-                {
-                  "colorMode": "cell",
-                  "colors": [
-                    "rgba(245, 54, 54, 0.9)",
-                    "rgba(237, 129, 40, 0.89)",
-                    "rgba(50, 172, 45, 0.97)"
-                  ],
-                  "decimals": 2,
-                  "pattern": "/.*/",
-                  "thresholds": [
-                    "0",
-                    "0",
-                    "1"
-                  ],
-                  "type": "number",
-                  "unit": "short"
-                }
-              ],
-              "targets": [
-                {
-                  "expr": "cluster_namespace_controller_pod_container:memory_oom:rate{container_name!=\"POD\", pod_name=~\"$pod\"}",
-                  "intervalFactor": 2,
-                  "legendFormat": "{{ container_name  }}",
-                  "refId": "A",
-                  "step": 4
-                }
-              ],
-              "title": "Out-of-memory",
-              "transform": "timeseries_aggregations",
-              "type": "table"
-            }
-          ],
-          "repeat": null,
-          "repeatIteration": null,
-          "repeatRowId": null,
-          "showTitle": true,
-          "title": "Memory",
-          "titleSize": "h6"
-        }
-      ],
-      "schemaVersion": 14,
-      "style": "dark",
-      "tags": [
-        "kubernetes"
-      ],
-      "templating": {
-        "list": [
+      "dashboard": {
+        "__inputs": [
           {
-            "current": {
-              "text": "prometheus",
-              "value": "prometheus"
-            },
-            "hide": 2,
-            "label": "",
-            "name": "datasource",
-            "options": [],
-            "query": "prometheus",
-            "refresh": 1,
-            "regex": "",
+            "description": "",
+            "label": "prometheus",
+            "name": "DS_PROMETHEUS",
+            "pluginId": "prometheus",
+            "pluginName": "Prometheus",
             "type": "datasource"
+          }
+        ],
+        "__requires": [
+          {
+            "id": "graph",
+            "name": "Graph",
+            "type": "panel",
+            "version": ""
           },
           {
-            "auto": true,
-            "auto_count": 30,
-            "auto_min": "30s",
-            "current": {
-              "text": "3m",
-              "value": "3m"
+            "id": "grafana",
+            "name": "Grafana",
+            "type": "grafana",
+            "version": "3.1.1"
+          },
+          {
+            "id": "prometheus",
+            "name": "Prometheus",
+            "type": "datasource",
+            "version": "1.0.0"
+          }
+        ],
+        "annotations": {
+          "list": []
+        },
+        "description": "Summary metrics about Pods running on Kubernetes nodes.",
+        "editable": true,
+        "gnetId": 482,
+        "graphTooltip": 1,
+        "hideControls": false,
+        "id": null,
+        "links": [
+          {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "tags": [
+              "kubernetes-app"
+            ],
+            "title": "Dashboards",
+            "type": "dashboards"
+          }
+        ],
+        "refresh": "10s",
+        "rows": [
+          {
+            "collapse": false,
+            "height": 355,
+            "panels": [
+              {
+                "alerting": {},
+                "aliasColors": {},
+                "bars": false,
+                "datasource": "$datasource",
+                "editable": true,
+                "error": false,
+                "fill": 1,
+                "grid": {},
+                "id": 6,
+                "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "hideZero": false,
+                  "max": true,
+                  "min": false,
+                  "rightSide": true,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+                },
+                "lines": true,
+                "linewidth": 2,
+                "links": [],
+                "minSpan": 6,
+                "nullPointMode": "connected",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "span": 6,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "expr": "sum (cluster_namespace_controller_pod_container:cpu_usage:rate{container_name!=\"POD\",pod_name=~\"$pod\"}) by (container_name)",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{ container_name }}",
+                    "refId": "A",
+                    "step": 4,
+                    "target": "groupByNode(exclude(perSecond(snap.$cluster.$node.intel.docker.$namespace.$pod.$container.stats.cgroups.cpu_stats.cpu_usage.total_usage), 'POD'), 7, 'sum')",
+                    "textEditor": false
+                  }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "CPU Usage (per container)",
+                "tooltip": {
+                  "msResolution": false,
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+                },
+                "transparent": false,
+                "type": "graph",
+                "xaxis": {
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "format": "short",
+                    "label": "of CPU cores",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                  },
+                  {
+                    "format": "short",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                  }
+                ]
+              },
+              {
+                "alerting": {},
+                "aliasColors": {},
+                "bars": false,
+                "datasource": "$datasource",
+                "editable": true,
+                "error": false,
+                "fill": 1,
+                "grid": {},
+                "id": 1,
+                "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": false,
+                  "max": true,
+                  "min": false,
+                  "rightSide": true,
+                  "show": true,
+                  "sideWidth": null,
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+                },
+                "lines": true,
+                "linewidth": 2,
+                "links": [],
+                "minSpan": 6,
+                "nullPointMode": "connected",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "span": 6,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "expr": "sum by(container_name) (cluster_namespace_controller_pod_container:memory_usage:bytes{container_name!=\"POD\",pod_name=~\"$pod\"})",
+                    "hide": false,
+                    "intervalFactor": 1,
+                    "legendFormat": " {{ container_name }}",
+                    "refId": "A",
+                    "step": 2,
+                    "target": "groupByNode(exclude(averageAbove(snap.$cluster.$node.intel.docker.$namespace.$pod.$container.stats.cgroups.memory_stats.usage.usage, 0), 'POD'), 7, 'sum')",
+                    "textEditor": false
+                  }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Total Memory Usage (per container)",
+                "tooltip": {
+                  "msResolution": false,
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "format": "decbytes",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                  },
+                  {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                  }
+                ]
+              },
+              {
+                "alerting": {},
+                "aliasColors": {},
+                "bars": false,
+                "datasource": "$datasource",
+                "editable": true,
+                "error": false,
+                "fill": 1,
+                "grid": {},
+                "id": 2,
+                "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": true,
+                  "show": true,
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+                },
+                "lines": true,
+                "linewidth": 2,
+                "links": [],
+                "minSpan": 6,
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "span": 12,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "expr": "sum by(pod_name) (rate(container_network_receive_bytes_total{pod_name=~\"$pod.*\"}[$interval]))",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{ pod_name }} Received",
+                    "refId": "A",
+                    "step": 2,
+                    "target": "groupByNode(exclude(perSecond(snap.$cluster.$node.intel.docker.$namespace.$pod.$container.stats.network.*.rx_bytes), 'POD'), 7, 'sum')",
+                    "textEditor": false
+                  },
+                  {
+                    "expr": "-sum by(pod_name)  (rate(container_network_transmit_bytes_total{pod_name=~\"$pod.*\"}[$interval]))",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{ pod_name }} Sent",
+                    "refId": "B",
+                    "step": 2
+                  }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Network Traffic (per pod)",
+                "tooltip": {
+                  "msResolution": false,
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "cumulative"
+                },
+                "transparent": false,
+                "type": "graph",
+                "xaxis": {
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "format": "decbytes",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                  },
+                  {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                  }
+                ]
+              }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "General",
+            "titleSize": "h6"
+          },
+          {
+            "collapse": false,
+            "height": 439,
+            "panels": [
+              {
+                "columns": [
+                  {
+                    "text": "Current",
+                    "value": "current"
+                  }
+                ],
+                "datasource": "prometheus",
+                "fontSize": "100%",
+                "id": 7,
+                "links": [],
+                "minSpan": 4,
+                "pageSize": null,
+                "scroll": true,
+                "showHeader": true,
+                "sort": {
+                  "col": 0,
+                  "desc": true
+                },
+                "span": 4,
+                "styles": [
+                  {
+                    "colorMode": null,
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "decimals": 2,
+                    "pattern": "/.*/",
+                    "thresholds": [
+                      "10000000",
+                      " 25000000"
+                    ],
+                    "type": "number",
+                    "unit": "decbytes"
+                  }
+                ],
+                "targets": [
+                  {
+                    "expr": "cluster_namespace_controller_pod_container:memory_usage:bytes{container_name!=\"POD\",pod_name=~\"$pod\"}",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{ container_name }}",
+                    "refId": "A",
+                    "step": 4
+                  }
+                ],
+                "title": "Memory Usage",
+                "transform": "timeseries_aggregations",
+                "type": "table"
+              },
+              {
+                "columns": [
+                  {
+                    "text": "Current",
+                    "value": "current"
+                  }
+                ],
+                "datasource": "$datasource",
+                "fontSize": "100%",
+                "id": 8,
+                "links": [],
+                "minSpan": 4,
+                "pageSize": null,
+                "scroll": true,
+                "showHeader": true,
+                "sort": {
+                  "col": 1,
+                  "desc": true
+                },
+                "span": 4,
+                "styles": [
+                  {
+                    "colorMode": "cell",
+                    "colors": [
+                      "rgba(50, 172, 45, 0.97)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(245, 54, 54, 0.9)"
+                    ],
+                    "decimals": 2,
+                    "pattern": "/.*/",
+                    "thresholds": [
+                      "80",
+                      "90"
+                    ],
+                    "type": "number",
+                    "unit": "percent"
+                  }
+                ],
+                "targets": [
+                  {
+                    "expr": "sum(100 - ((cluster_namespace_controller_pod_container:spec_memory_limit_bytes{container_name!=\"POD\",pod_name=~\"$pod\"} - cluster_namespace_controller_pod_container:memory_usage:bytes{container_name!=\"POD\",pod_name=~\"$pod\"})  * 100 / cluster_namespace_controller_pod_container:spec_memory_limit_bytes{container_name!=\"POD\",pod_name=~\"$pod\"}) ) by (pod_name) ",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "legendFormat": "{{pod_name}}",
+                    "refId": "A",
+                    "step": 4
+                  }
+                ],
+                "title": "Memory usage (in percent of limit)",
+                "transform": "timeseries_aggregations",
+                "type": "table"
+              },
+              {
+                "columns": [
+                  {
+                    "text": "Current",
+                    "value": "current"
+                  }
+                ],
+                "datasource": "$datasource",
+                "fontSize": "100%",
+                "id": 9,
+                "links": [],
+                "minSpan": 4,
+                "pageSize": null,
+                "scroll": true,
+                "showHeader": true,
+                "sort": {
+                  "col": 0,
+                  "desc": true
+                },
+                "span": 4,
+                "styles": [
+                  {
+                    "colorMode": "cell",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "decimals": 2,
+                    "pattern": "/.*/",
+                    "thresholds": [
+                      "0",
+                      "0",
+                      "1"
+                    ],
+                    "type": "number",
+                    "unit": "short"
+                  }
+                ],
+                "targets": [
+                  {
+                    "expr": "cluster_namespace_controller_pod_container:memory_oom:rate{container_name!=\"POD\", pod_name=~\"$pod\"}",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{ container_name  }}",
+                    "refId": "A",
+                    "step": 4
+                  }
+                ],
+                "title": "Out-of-memory",
+                "transform": "timeseries_aggregations",
+                "type": "table"
+              }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Memory",
+            "titleSize": "h6"
+          },
+          {
+            "collapse": false,
+            "height": 250,
+            "panels": [
+              {
+                "columns": [
+                  {
+                    "text": "Current",
+                    "value": "current"
+                  }
+                ],
+                "datasource": "$datasource",
+                "fontSize": "100%",
+                "id": 10,
+                "links": [],
+                "pageSize": 5,
+                "scroll": true,
+                "showHeader": true,
+                "sort": {
+                  "col": 1,
+                  "desc": true
+                },
+                "span": 12,
+                "styles": [
+                  {
+                    "colorMode": "cell",
+                    "colors": [
+                      "rgba(50, 172, 45, 0.97)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(245, 54, 54, 0.9)"
+                    ],
+                    "decimals": 2,
+                    "pattern": "/.*/",
+                    "thresholds": [
+                      "80",
+                      "90"
+                    ],
+                    "type": "number",
+                    "unit": "percent"
+                  }
+                ],
+                "targets": [
+                  {
+                    "expr": "sum(cluster_namespace_controller_pod_container:cpu_usage:rate{container_name!=\"POD\",pod=~\"$pod\"}) by (pod) / (sum(kube_pod_container_resource_limits_cpu_cores{namespace=\"monitoring\",pod=~\"$pod\"}) by (pod) / 100) /10",
+                    "intervalFactor": 2,
+                    "legendFormat": " {{ pod }}",
+                    "refId": "A",
+                    "step": 2
+                  }
+                ],
+                "title": "CPU Usage (in percent of limit)",
+                "transform": "timeseries_aggregations",
+                "type": "table"
+              }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": false,
+            "title": "Dashboard Row",
+            "titleSize": "h6"
+          }
+        ],
+        "schemaVersion": 14,
+        "style": "dark",
+        "tags": [
+          "kubernetes"
+        ],
+        "templating": {
+          "list": [
+            {
+              "current": {
+                "text": "prometheus",
+                "value": "prometheus"
+              },
+              "hide": 2,
+              "label": "",
+              "name": "datasource",
+              "options": [],
+              "query": "prometheus",
+              "refresh": 1,
+              "regex": "",
+              "type": "datasource"
             },
-            "hide": 0,
-            "label": "Interval",
-            "name": "interval",
-            "options": [
-              {
-                "selected": false,
-                "text": "auto",
-                "value": "$__auto_interval"
-              },
-              {
-                "selected": false,
-                "text": "30s",
-                "value": "30s"
-              },
-              {
-                "selected": false,
-                "text": "1m",
-                "value": "1m"
-              },
-              {
-                "selected": false,
-                "text": "2m",
-                "value": "2m"
-              },
-              {
-                "selected": true,
+            {
+              "auto": true,
+              "auto_count": 30,
+              "auto_min": "30s",
+              "current": {
                 "text": "3m",
                 "value": "3m"
               },
-              {
-                "selected": false,
-                "text": "5m",
-                "value": "5m"
-              },
-              {
-                "selected": false,
-                "text": "7m",
-                "value": "7m"
-              },
-              {
-                "selected": false,
-                "text": "10m",
-                "value": "10m"
-              },
-              {
-                "selected": false,
-                "text": "30m",
-                "value": "30m"
-              },
-              {
-                "selected": false,
-                "text": "1h",
-                "value": "1h"
-              },
-              {
-                "selected": false,
-                "text": "6h",
-                "value": "6h"
-              },
-              {
-                "selected": false,
-                "text": "12h",
-                "value": "12h"
-              },
-              {
-                "selected": false,
-                "text": "1d",
-                "value": "1d"
-              },
-              {
-                "selected": false,
-                "text": "7d",
-                "value": "7d"
-              },
-              {
-                "selected": false,
-                "text": "14d",
-                "value": "14d"
-              },
-              {
-                "selected": false,
-                "text": "30d",
-                "value": "30d"
-              }
-            ],
-            "query": "30s,1m,2m,3m,5m,7m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
-            "refresh": 2,
-            "type": "interval"
-          },
-          {
-            "allValue": null,
-            "current": {
-              "text": "All",
-              "value": "$__all"
+              "hide": 0,
+              "label": "Interval",
+              "name": "interval",
+              "options": [
+                {
+                  "selected": false,
+                  "text": "auto",
+                  "value": "$__auto_interval"
+                },
+                {
+                  "selected": false,
+                  "text": "30s",
+                  "value": "30s"
+                },
+                {
+                  "selected": false,
+                  "text": "1m",
+                  "value": "1m"
+                },
+                {
+                  "selected": false,
+                  "text": "2m",
+                  "value": "2m"
+                },
+                {
+                  "selected": true,
+                  "text": "3m",
+                  "value": "3m"
+                },
+                {
+                  "selected": false,
+                  "text": "5m",
+                  "value": "5m"
+                },
+                {
+                  "selected": false,
+                  "text": "7m",
+                  "value": "7m"
+                },
+                {
+                  "selected": false,
+                  "text": "10m",
+                  "value": "10m"
+                },
+                {
+                  "selected": false,
+                  "text": "30m",
+                  "value": "30m"
+                },
+                {
+                  "selected": false,
+                  "text": "1h",
+                  "value": "1h"
+                },
+                {
+                  "selected": false,
+                  "text": "6h",
+                  "value": "6h"
+                },
+                {
+                  "selected": false,
+                  "text": "12h",
+                  "value": "12h"
+                },
+                {
+                  "selected": false,
+                  "text": "1d",
+                  "value": "1d"
+                },
+                {
+                  "selected": false,
+                  "text": "7d",
+                  "value": "7d"
+                },
+                {
+                  "selected": false,
+                  "text": "14d",
+                  "value": "14d"
+                },
+                {
+                  "selected": false,
+                  "text": "30d",
+                  "value": "30d"
+                }
+              ],
+              "query": "30s,1m,2m,3m,5m,7m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+              "refresh": 2,
+              "type": "interval"
             },
-            "datasource": "$datasource",
-            "hide": 0,
-            "includeAll": true,
-            "label": null,
-            "multi": false,
-            "name": "namespace",
-            "options": [],
-            "query": "label_values(kube_pod_info, namespace)",
-            "refresh": 1,
-            "regex": "",
-            "sort": 0,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-          },
-          {
-            "allValue": null,
-            "current": {
-              "text": "All",
-              "value": "$__all"
+            {
+              "allValue": null,
+              "current": {
+                "text": "monitoring",
+                "value": "monitoring"
+              },
+              "datasource": "$datasource",
+              "hide": 0,
+              "includeAll": true,
+              "label": null,
+              "multi": false,
+              "name": "namespace",
+              "options": [],
+              "query": "label_values(kube_pod_info, namespace)",
+              "refresh": 1,
+              "regex": "",
+              "sort": 0,
+              "tagValuesQuery": "",
+              "tags": [],
+              "tagsQuery": "",
+              "type": "query",
+              "useTags": false
             },
-            "datasource": "$datasource",
-            "hide": 0,
-            "includeAll": true,
-            "label": null,
-            "multi": false,
-            "name": "pod",
-            "options": [],
-            "query": "label_values(kube_pod_info{namespace=~\"$namespace\"}, pod)",
-            "refresh": 1,
-            "regex": "",
-            "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-          }
-        ]
+            {
+              "allValue": null,
+              "current": {
+                "tags": [],
+                "text": "prometheus-k8s-0",
+                "value": "prometheus-k8s-0"
+              },
+              "datasource": "$datasource",
+              "hide": 0,
+              "includeAll": true,
+              "label": null,
+              "multi": false,
+              "name": "pod",
+              "options": [],
+              "query": "label_values(kube_pod_info{namespace=~\"$namespace\"}, pod)",
+              "refresh": 1,
+              "regex": "",
+              "sort": 1,
+              "tagValuesQuery": "",
+              "tags": [],
+              "tagsQuery": "",
+              "type": "query",
+              "useTags": false
+            }
+          ]
+        },
+        "time": {
+          "from": "now-30m",
+          "to": "now"
+        },
+        "timepicker": {
+          "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+          ],
+          "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+          ]
+        },
+        "timezone": "browser",
+        "title": "Kubernetes Pod",
+        "version": 7
       },
-      "time": {
-        "from": "now-30m",
-        "to": "now"
-      },
-      "timepicker": {
-        "refresh_intervals": [
-          "5s",
-          "10s",
-          "30s",
-          "1m",
-          "5m",
-          "15m",
-          "30m",
-          "1h",
-          "2h",
-          "1d"
-        ],
-        "time_options": [
-          "5m",
-          "15m",
-          "1h",
-          "6h",
-          "12h",
-          "24h",
-          "2d",
-          "7d",
-          "30d"
-        ]
-      },
-      "timezone": "browser",
-      "title": "Kubernetes Pod",
-      "version": 154
-    }
-    ,
       "inputs": [
         {
           "name": "DS_PROMETHEUS",

--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-rules.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-rules.yaml
@@ -76,13 +76,13 @@ data:
       )
 
     cluster_namespace_controller_pod_container:cpu_usage:rate =
-      sum by (cluster,namespace,controller,pod_name,container_name) (
+      sum by (cluster,namespace,pod,pod_name,container_name) (
         label_replace(
           irate(
             container_cpu_usage_seconds_total{container_name!=""}[5m]
           ),
-          "controller", "$1",
-          "pod_name", "^(.*)-[a-z0-9]+"
+          "pod", "$1",
+          "pod_name", "^(.*)"
         )
       )
 

--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s.yaml
@@ -16,7 +16,7 @@ spec:
       # memory. Modify based on your target and time-series count for
       # production use. This value is mainly meant for demonstration/testing
       # purposes.
-      memory: 400Mi
+      memory: 2Gi
   alerting:
     alertmanagers:
     - namespace: monitoring


### PR DESCRIPTION
- Modify rules, to be able to extract CPU limit usage in percent
- Add `CPU limit usage` element to dashboard
- Increase initial memory limit to `2Gi` according to recommendation.