### PR TITLE
NOISSUE Adding persistent EBS storage vol to prometheus-k8s

### DIFF
--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s.yaml
@@ -22,3 +22,8 @@ spec:
     - namespace: monitoring
       name: alertmanager-main
       port: web
+  storage:
+    class: gp2
+    resources:
+      requests:
+        storage: 300Gi


### PR DESCRIPTION
Storageclass named "gp2" is created with foodpanda/k8s-terraform repo. It transform prometheus-k8s to StatefulSet and managed by prometheus-operator